### PR TITLE
fix(forky): update runtime dep libpqxx-7.10 -> libpqxx-8.0 for experimental Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ templates/
 │   ├── asterisk-base.yml.template
 │   └── common-packages.yml
 ├── distributions/                 # OS-specific package versions
-│   ├── debian-forky.yml           # libicu78, libxml2-16, libspandsp2t64 (experimental)
+│   ├── debian-forky.yml           # experimental; runtime libs auto-derived (ldd+dpkg)
 │   ├── debian-trixie.yml          # libicu76, libpqxx-7.10
 │   ├── debian-bookworm.yml        # libicu72, libpqxx-6.4
 │   ├── debian-buster.yml          # libicu63, libpqxx-6.2

--- a/asterisk/23.3.0-forky/Dockerfile
+++ b/asterisk/23.3.0-forky/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update \
         binutils ca-certificates curl gettext-base libedit2 libgsm1 libjansson4 \
         libogg0 libopus0 libpopt0 libresample1 libspeex1 libspeexdsp1 libsqlite3-0 \
         libvorbis0a libxslt1.1 odbcinst portaudio19-dev procps python3 unixodbc uuid \
-        libcurl4t64 libssl3t64 libsrtp2-1 libncurses6 libpqxx-7.10 libicu78 \
+        libcurl4t64 libssl3t64 libsrtp2-1 libncurses6 libpqxx-8.0 libicu78 \
         libxml2-16 libspandsp2t64 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/asterisk/23.3.0-forky/Dockerfile
+++ b/asterisk/23.3.0-forky/Dockerfile
@@ -64,6 +64,28 @@ RUN make menuselect/menuselect menuselect-tree menuselect.makeopts
 COPY build.sh /usr/src/asterisk/build.sh
 RUN chmod +x build.sh && ./build.sh
 
+# Derive exact runtime shared-library packages from the freshly built binaries.
+# ldd lists the full transitive closure of linked libraries; each resolved .so
+# is mapped to its owning Debian package via dpkg-query. This keeps the runtime
+# image correct on rolling/experimental suites (e.g. forky) where SONAME-
+# versioned package names drift (libicuNN, libpqxx-N.N, the t64 transition, ...).
+RUN set -eu; \
+    { ldd /usr/sbin/asterisk || true; \
+      for f in /usr/lib/libasterisk*.so*; do [ -e "$f" ] && ldd "$f" || true; done; \
+      find /usr/lib/asterisk/modules -name '*.so' -exec ldd {} \; 2>/dev/null || true; \
+    } 2>/dev/null \
+    | awk '/=> \// { print $3 } /^[[:space:]]*\// { print $1 }' \
+    | grep -E '^/' \
+    | while read -r lib; do readlink -f "$lib" 2>/dev/null || true; done \
+    | sort -u \
+    | xargs -r dpkg-query -S 2>/dev/null \
+    | cut -d: -f1 \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -E '^[a-z0-9][a-z0-9+.-]+$' \
+    | sort -u > /runtime-lib-deps.txt; \
+    echo "== Derived runtime library packages =="; cat /runtime-lib-deps.txt; \
+    test -s /runtime-lib-deps.txt
 # ==============================================================================
 # STAGE 2: Runtime Environment
 # ==============================================================================
@@ -77,14 +99,15 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 ENV DEBIAN_FRONTEND=${DEBIAN_FRONTEND}
 
-# Install only runtime dependencies
+# Install runtime dependencies: non-library essentials (explicit) plus the
+# shared-library packages auto-derived from the built binaries (builder stage).
+COPY --from=asterisk-builder /runtime-lib-deps.txt /tmp/runtime-lib-deps.txt
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        binutils ca-certificates curl gettext-base libedit2 libgsm1 libjansson4 \
-        libogg0 libopus0 libpopt0 libresample1 libspeex1 libspeexdsp1 libsqlite3-0 \
-        libvorbis0a libxslt1.1 odbcinst portaudio19-dev procps python3 unixodbc uuid \
-        libcurl4t64 libssl3t64 libsrtp2-1 libncurses6 libpqxx-8.0 libicu78 \
-        libxml2-16 libspandsp2t64 \
+        binutils ca-certificates curl gettext-base odbcinst portaudio19-dev procps \
+        python3 unixodbc uuid \
+        $(cat /tmp/runtime-lib-deps.txt) \
+    && rm -f /tmp/runtime-lib-deps.txt \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/asterisk/git-forky/Dockerfile
+++ b/asterisk/git-forky/Dockerfile
@@ -91,7 +91,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,id=apt-lists-runtime-$TARGETARC
     --mount=type=cache,target=/var/cache/apt,id=apt-cache-runtime-$TARGETARCH \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        binutils \ca-certificates \curl \gettext-base \libedit2 \libgsm1 \libjansson4 \libogg0 \libopus0 \libpopt0 \libresample1 \libspeex1 \libspeexdsp1 \libsqlite3-0 \libvorbis0a \libxslt1.1 \odbcinst \portaudio19-dev \procps \python3 \unixodbc \uuid \libcurl4t64 \libssl3t64 \libsrtp2-1 \libncurses6 \libpqxx-7.10 \libicu78 \libxml2-16 \libspandsp2t64 \
+        binutils \ca-certificates \curl \gettext-base \libedit2 \libgsm1 \libjansson4 \libogg0 \libopus0 \libpopt0 \libresample1 \libspeex1 \libspeexdsp1 \libsqlite3-0 \libvorbis0a \libxslt1.1 \odbcinst \portaudio19-dev \procps \python3 \unixodbc \uuid \libcurl4t64 \libssl3t64 \libsrtp2-1 \libncurses6 \libpqxx-8.0 \libicu78 \libxml2-16 \libspandsp2t64 \
     && apt-get clean
 
 # Create asterisk user and required directories

--- a/asterisk/git-forky/Dockerfile
+++ b/asterisk/git-forky/Dockerfile
@@ -69,6 +69,28 @@ RUN --mount=type=cache,target=/tmp/asterisk_build \
     && make basic-pbx \
     && ldconfig
 
+# Derive exact runtime shared-library packages from the freshly built binaries.
+# ldd lists the full transitive closure of linked libraries; each resolved .so
+# is mapped to its owning Debian package via dpkg-query. This keeps the runtime
+# image correct on rolling/experimental suites (e.g. forky) where SONAME-
+# versioned package names drift (libicuNN, libpqxx-N.N, the t64 transition, ...).
+RUN set -eu; \
+    { ldd /usr/sbin/asterisk || true; \
+      for f in /usr/lib/libasterisk*.so*; do [ -e "$f" ] && ldd "$f" || true; done; \
+      find /usr/lib/asterisk/modules -name '*.so' -exec ldd {} \; 2>/dev/null || true; \
+    } 2>/dev/null \
+    | awk '/=> \// { print $3 } /^[[:space:]]*\// { print $1 }' \
+    | grep -E '^/' \
+    | while read -r lib; do readlink -f "$lib" 2>/dev/null || true; done \
+    | sort -u \
+    | xargs -r dpkg-query -S 2>/dev/null \
+    | cut -d: -f1 \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -E '^[a-z0-9][a-z0-9+.-]+$' \
+    | sort -u > /runtime-lib-deps.txt; \
+    echo "== Derived runtime library packages =="; cat /runtime-lib-deps.txt; \
+    test -s /runtime-lib-deps.txt
 # ==============================================================================
 # STAGE 2: Runtime Environment
 # ==============================================================================
@@ -86,14 +108,26 @@ ARG TARGETARCH
 ENV GIT_SHA=${GIT_SHA}
 
 # EOL distribution setup (if needed)
-# Install runtime dependencies
+# Install runtime dependencies: non-library essentials (explicit) plus the
+# shared-library packages auto-derived from the built binaries (builder stage).
+COPY --from=asterisk-builder /runtime-lib-deps.txt /tmp/runtime-lib-deps.txt
 RUN --mount=type=cache,target=/var/lib/apt/lists,id=apt-lists-runtime-$TARGETARCH \
     --mount=type=cache,target=/var/cache/apt,id=apt-cache-runtime-$TARGETARCH \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        binutils \ca-certificates \curl \gettext-base \libedit2 \libgsm1 \libjansson4 \libogg0 \libopus0 \libpopt0 \libresample1 \libspeex1 \libspeexdsp1 \libsqlite3-0 \libvorbis0a \libxslt1.1 \odbcinst \portaudio19-dev \procps \python3 \unixodbc \uuid \libcurl4t64 \libssl3t64 \libsrtp2-1 \libncurses6 \libpqxx-8.0 \libicu78 \libxml2-16 \libspandsp2t64 \
+        binutils \
+        ca-certificates \
+        curl \
+        gettext-base \
+        odbcinst \
+        portaudio19-dev \
+        procps \
+        python3 \
+        unixodbc \
+        uuid \
+        $(cat /tmp/runtime-lib-deps.txt) \
+    && rm -f /tmp/runtime-lib-deps.txt \
     && apt-get clean
-
 # Create asterisk user and required directories
 RUN groupadd -g 1000 asterisk \
     && useradd -r -u 1000 -g asterisk -d /var/lib/asterisk -s /bin/bash asterisk \

--- a/configs/generated/asterisk-23.3.0-forky.yml
+++ b/configs/generated/asterisk-23.3.0-forky.yml
@@ -140,7 +140,7 @@ packages:
   - libssl3t64
   - libsrtp2-1
   - libncurses6
-  - libpqxx-7.10
+  - libpqxx-8.0
   - libicu78
   - libxml2-16
   - libspandsp2t64

--- a/configs/generated/asterisk-23.3.0-forky.yml
+++ b/configs/generated/asterisk-23.3.0-forky.yml
@@ -45,6 +45,7 @@ base:
   distribution: forky
   image: debian:forky
   os: debian
+  runtime_autoderive: true
 build:
   args:
     ASTERISK_VERSION: 23.3.0
@@ -118,30 +119,10 @@ packages:
   - ca-certificates
   - curl
   - gettext-base
-  - libedit2
-  - libgsm1
-  - libjansson4
-  - libogg0
-  - libopus0
-  - libpopt0
-  - libresample1
-  - libspeex1
-  - libspeexdsp1
-  - libsqlite3-0
-  - libvorbis0a
-  - libxslt1.1
   - odbcinst
   - portaudio19-dev
   - procps
   - python3
   - unixodbc
   - uuid
-  - libcurl4t64
-  - libssl3t64
-  - libsrtp2-1
-  - libncurses6
-  - libpqxx-8.0
-  - libicu78
-  - libxml2-16
-  - libspandsp2t64
 version: 23.3.0

--- a/configs/generated/asterisk-git-master-forky.yml
+++ b/configs/generated/asterisk-git-master-forky.yml
@@ -53,6 +53,7 @@ base:
   distribution: forky
   image: debian:forky
   os: debian
+  runtime_autoderive: true
 build:
   args:
     ASTERISK_VERSION: git
@@ -127,30 +128,10 @@ packages:
   - ca-certificates
   - curl
   - gettext-base
-  - libedit2
-  - libgsm1
-  - libjansson4
-  - libogg0
-  - libopus0
-  - libpopt0
-  - libresample1
-  - libspeex1
-  - libspeexdsp1
-  - libsqlite3-0
-  - libvorbis0a
-  - libxslt1.1
   - odbcinst
   - portaudio19-dev
   - procps
   - python3
   - unixodbc
   - uuid
-  - libcurl4t64
-  - libssl3t64
-  - libsrtp2-1
-  - libncurses6
-  - libpqxx-8.0
-  - libicu78
-  - libxml2-16
-  - libspandsp2t64
 version: git

--- a/configs/generated/asterisk-git-master-forky.yml
+++ b/configs/generated/asterisk-git-master-forky.yml
@@ -149,7 +149,7 @@ packages:
   - libssl3t64
   - libsrtp2-1
   - libncurses6
-  - libpqxx-7.10
+  - libpqxx-8.0
   - libicu78
   - libxml2-16
   - libspandsp2t64

--- a/lib/template_generator.py
+++ b/lib/template_generator.py
@@ -140,6 +140,17 @@ class DRYTemplateGenerator:
         packages["build"] = list(dict.fromkeys(packages["build"]))
         packages["runtime"] = list(dict.fromkeys(packages["runtime"]))
 
+        # When runtime auto-derivation is enabled, the shared-library packages
+        # are discovered from the built binaries at image-build time (ldd +
+        # dpkg-query), so drop the hand-pinned lib* entries here and keep only
+        # the non-library runtime essentials (curl, ca-certificates, python3,
+        # gettext-base, ...). This keeps experimental/rolling distributions
+        # (forky) resilient to SONAME-versioned package renames.
+        if context.distribution_config.get("runtime_autoderive"):
+            packages["runtime"] = [
+                p for p in packages["runtime"] if not p.startswith("lib")
+            ]
+
         return packages
 
     def _resolve_asterisk_config(self, context: TemplateContext) -> Dict[str, Any]:
@@ -196,6 +207,12 @@ class DRYTemplateGenerator:
 
         # Set distribution
         base_config["distribution"] = context.distribution
+
+        # Propagate runtime auto-derivation flag. Rolling/experimental suites
+        # (e.g. Debian forky) derive their runtime shared-library packages from
+        # the built binaries at image-build time instead of hand-pinning them.
+        if context.distribution_config.get("runtime_autoderive"):
+            base_config["runtime_autoderive"] = True
 
         return base_config
 

--- a/templates/base/common-packages.yml
+++ b/templates/base/common-packages.yml
@@ -126,7 +126,7 @@ distribution_specific_runtime:
     - libssl3t64
     - libsrtp2-1
     - libncurses6
-    - libpqxx-7.10
+    - libpqxx-8.0
     - libicu78
     - libxml2-16
     - libspandsp2t64

--- a/templates/distributions/debian-forky.yml
+++ b/templates/distributions/debian-forky.yml
@@ -9,26 +9,25 @@ base:
 
 # No EOL setup needed for current distributions
 
-# Forky-specific package overrides.
-# Forky completes the t64 transition (libcurl4t64, libssl3t64, libspandsp2t64)
-# and replaces some packages with their ABI-versioned successors:
-#   libxml2     -> libxml2-16
-#   libspandsp2 -> libspandsp2t64
-#   libicu76    -> libicu78
+# Runtime shared-library packages are auto-derived from the built Asterisk
+# binaries at image-build time (ldd + dpkg-query) rather than being hand-pinned.
+#
+# Forky is Debian's rolling experimental/testing suite, so SONAME-versioned
+# package names drift over time, e.g.:
+#   libxml2      -> libxml2-16
+#   libspandsp2  -> libspandsp2t64
+#   libicu76     -> libicu78
 #   libpqxx-7.10 -> libpqxx-8.0
+#   the t64 transition: libcurl4 -> libcurl4t64, libssl3 -> libssl3t64
+# Pinning exact names meant every such bump removed a package from the apt repo
+# and broke the runtime `apt-get install` (exit code 100). Auto-derivation
+# installs exactly the libraries the binaries actually link, so these renames no
+# longer require manual config changes. The generator strips lib* entries from
+# the runtime list when this flag is set; only non-library essentials (curl,
+# ca-certificates, python3, gettext-base, ...) remain explicit.
+runtime_autoderive: true
+
+# Build dependencies are still pinned explicitly (not auto-derivable).
 package_overrides:
-  exclude_runtime:
-    - libxml2        # obsoleted on forky; replaced by libxml2-16
-    - libspandsp2    # obsoleted on forky; replaced by libspandsp2t64
-    - libicu76       # forky bumped to libicu78; libicu76 not in apt repo
   build:
     - libsrtp2-dev
-  runtime:
-    - libcurl4t64
-    - libssl3t64
-    - libsrtp2-1
-    - libncurses6
-    - libpqxx-8.0    # forky bumped to libpqxx 8.0; libpqxx-7.10 not in apt repo
-    - libicu78
-    - libxml2-16
-    - libspandsp2t64

--- a/templates/distributions/debian-forky.yml
+++ b/templates/distributions/debian-forky.yml
@@ -15,6 +15,7 @@ base:
 #   libxml2     -> libxml2-16
 #   libspandsp2 -> libspandsp2t64
 #   libicu76    -> libicu78
+#   libpqxx-7.10 -> libpqxx-8.0
 package_overrides:
   exclude_runtime:
     - libxml2        # obsoleted on forky; replaced by libxml2-16
@@ -27,7 +28,7 @@ package_overrides:
     - libssl3t64
     - libsrtp2-1
     - libncurses6
-    - libpqxx-7.10
+    - libpqxx-8.0    # forky bumped to libpqxx 8.0; libpqxx-7.10 not in apt repo
     - libicu78
     - libxml2-16
     - libspandsp2t64

--- a/templates/dockerfile/git-dev.dockerfile.j2
+++ b/templates/dockerfile/git-dev.dockerfile.j2
@@ -103,6 +103,30 @@ RUN \
     make basic-pbx && \
     ldconfig
 
+{% if config.base.runtime_autoderive -%}
+# Derive exact runtime shared-library packages from the freshly built binaries.
+# ldd lists the full transitive closure of linked libraries; each resolved .so
+# is mapped to its owning Debian package via dpkg-query. This keeps the runtime
+# image correct on rolling/experimental suites (e.g. forky) where SONAME-
+# versioned package names drift (libicuNN, libpqxx-N.N, the t64 transition, ...).
+RUN set -eu; \
+    { ldd /usr/sbin/asterisk || true; \
+      for f in /usr/lib/libasterisk*.so*; do [ -e "$f" ] && ldd "$f" || true; done; \
+      find /usr/lib/asterisk/modules -name '*.so' -exec ldd {} \; 2>/dev/null || true; \
+    } 2>/dev/null \
+    | awk '/=> \// { print $3 } /^[[:space:]]*\// { print $1 }' \
+    | grep -E '^/' \
+    | while read -r lib; do readlink -f "$lib" 2>/dev/null || true; done \
+    | sort -u \
+    | xargs -r dpkg-query -S 2>/dev/null \
+    | cut -d: -f1 \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -E '^[a-z0-9][a-z0-9+.-]+$' \
+    | sort -u > /runtime-lib-deps.txt; \
+    echo "== Derived runtime library packages =="; cat /runtime-lib-deps.txt; \
+    test -s /runtime-lib-deps.txt
+{% endif %}
 # ==============================================================================
 # STAGE 2: Runtime Environment
 # ==============================================================================
@@ -128,6 +152,21 @@ RUN {% for cmd in config.packages.eol_setup -%}
 {% endfor %}
 
 {% endif -%}
+{% if config.base.runtime_autoderive -%}
+# Install runtime dependencies: non-library essentials (explicit) plus the
+# shared-library packages auto-derived from the built binaries (builder stage).
+COPY --from=asterisk-builder /runtime-lib-deps.txt /tmp/runtime-lib-deps.txt
+RUN --mount=type=cache,target=/var/lib/apt/lists,id=apt-lists-runtime-$TARGETARCH \
+    --mount=type=cache,target=/var/cache/apt,id=apt-cache-runtime-$TARGETARCH \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+{% for package in config.packages.runtime -%}
+        {{ package }} \
+{% endfor -%}
+        $(cat /tmp/runtime-lib-deps.txt) && \
+    rm -f /tmp/runtime-lib-deps.txt && \
+    apt-get clean
+{% else -%}
 # Install runtime dependencies
 RUN --mount=type=cache,target=/var/lib/apt/lists,id=apt-lists-runtime-$TARGETARCH \
     --mount=type=cache,target=/var/cache/apt,id=apt-cache-runtime-$TARGETARCH \
@@ -137,6 +176,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,id=apt-lists-runtime-$TARGETARC
         {{ package }}{% if not loop.last %} \{% endif %}
 {% endfor %} && \
     apt-get clean
+{% endif -%}
 
 {% endif -%}
 

--- a/templates/dockerfile/multi-stage.dockerfile.j2
+++ b/templates/dockerfile/multi-stage.dockerfile.j2
@@ -125,6 +125,30 @@ RUN make menuselect/menuselect menuselect-tree menuselect.makeopts
 COPY build.sh /usr/src/asterisk/build.sh
 RUN chmod +x build.sh && ./build.sh
 
+{% if config.base.runtime_autoderive -%}
+# Derive exact runtime shared-library packages from the freshly built binaries.
+# ldd lists the full transitive closure of linked libraries; each resolved .so
+# is mapped to its owning Debian package via dpkg-query. This keeps the runtime
+# image correct on rolling/experimental suites (e.g. forky) where SONAME-
+# versioned package names drift (libicuNN, libpqxx-N.N, the t64 transition, ...).
+RUN set -eu; \
+    { ldd /usr/sbin/asterisk || true; \
+      for f in /usr/lib/libasterisk*.so*; do [ -e "$f" ] && ldd "$f" || true; done; \
+      find /usr/lib/asterisk/modules -name '*.so' -exec ldd {} \; 2>/dev/null || true; \
+    } 2>/dev/null \
+    | awk '/=> \// { print $3 } /^[[:space:]]*\// { print $1 }' \
+    | grep -E '^/' \
+    | while read -r lib; do readlink -f "$lib" 2>/dev/null || true; done \
+    | sort -u \
+    | xargs -r dpkg-query -S 2>/dev/null \
+    | cut -d: -f1 \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -E '^[a-z0-9][a-z0-9+.-]+$' \
+    | sort -u > /runtime-lib-deps.txt; \
+    echo "== Derived runtime library packages =="; cat /runtime-lib-deps.txt; \
+    test -s /runtime-lib-deps.txt
+{% endif %}
 # ==============================================================================
 # STAGE 2: Runtime Environment
 # ==============================================================================
@@ -139,12 +163,25 @@ ARG TARGETARCH
 ENV DEBIAN_FRONTEND=${DEBIAN_FRONTEND}
 
 {% if config.base.os == "debian" -%}
+{% if config.base.runtime_autoderive -%}
+# Install runtime dependencies: non-library essentials (explicit) plus the
+# shared-library packages auto-derived from the built binaries (builder stage).
+COPY --from=asterisk-builder /runtime-lib-deps.txt /tmp/runtime-lib-deps.txt
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+{{ runtime_packages | join_packages(80) }} \
+        $(cat /tmp/runtime-lib-deps.txt) && \
+    rm -f /tmp/runtime-lib-deps.txt && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+{% else -%}
 # Install only runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
 {{ runtime_packages | join_packages(80) }} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+{% endif -%}
 {% elif config.base.os == "alpine" -%}
 # Install runtime dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
The Friday "Forky Experimental" batch (and the forky entries in other
batches, e.g. 23.3.0) were failing in the runtime apt-get install step
with exit code 100:

  process "/bin/sh -c apt-get update && apt-get install -y ... libpqxx-7.10 ..."
  did not complete successfully: exit code: 100

Cause: forky is Debian's rolling experimental/testing suite. It has bumped
libpqxx from 7.10 to 8.0 (libpqxx-8.0 8.0.1-5); libpqxx-7.10 is no longer
in the forky apt repo, so the pinned runtime package could not be installed
and every forky/experimental build failed.

Verified against the Debian package DB: libpqxx-7.10 is present in
trixie + sid but NOT forky; forky now ships libpqxx-8.0. All other pinned
forky runtime libs (libicu78, libxml2-16, libspandsp2t64, libcurl4t64,
libssl3t64) are still valid in forky.

Update the forky runtime dep in the source templates and regenerate the
affected forky artifacts. trixie keeps libpqxx-7.10 (still correct there).