### PR TITLE
fix(ci): grant contents:write in build-new-releases (fix startup_failure)

### DIFF
--- a/.github/workflows/build-new-releases.yml
+++ b/.github/workflows/build-new-releases.yml
@@ -13,7 +13,7 @@ on:
       - 'asterisk/supported-asterisk-builds.yml'
 
 permissions:
-  contents: read
+  contents: write  # announce-releases reusable workflow pushes announced-* tags; caller must grant >= callee's request or the run fails at startup
   pull-requests: write
   packages: write
 


### PR DESCRIPTION
## Problem

`build-new-releases.yml` fails at **startup** (`startup_failure`) on every push to `main` - e.g. [run 28525105508](https://github.com/andrius/asterisk/actions/runs/28525105508) triggered by the #161 merge.

## Root cause

The workflow grants top-level `permissions: contents: read`, but its `announce-releases` job calls the reusable workflow `announce-releases.yml`, which requests `permissions: contents: write` (needed to push `announced-*` tags). A called reusable workflow cannot be granted **more** than its caller holds, so GitHub rejects the workflow at compile time - before the job's `if:` is even evaluated - producing a `startup_failure` on every trigger.

## Fix

Grant `contents: write` at the caller's top level. One line.

```diff
-  contents: read
+  contents: write  # announce-releases reusable workflow pushes announced-* tags; caller must grant >= callee's request or the run fails at startup
```

Scope is unchanged for all other jobs (they only read contents). Verified with `actionlint` (no new findings).