### PR TITLE
chore(ci): bump GitHub Actions to node24 majors (fix node20 deprecation)

### DIFF
--- a/.github/actions/generate-build-matrix/action.yml
+++ b/.github/actions/generate-build-matrix/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
 

--- a/.github/workflows/announce-releases.yml
+++ b/.github/workflows/announce-releases.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-batch-friday.yml
+++ b/.github/workflows/build-batch-friday.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate build matrix
         id: generate

--- a/.github/workflows/build-batch-monday.yml
+++ b/.github/workflows/build-batch-monday.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate build matrix
         id: generate

--- a/.github/workflows/build-batch-thursday.yml
+++ b/.github/workflows/build-batch-thursday.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate build matrix
         id: generate

--- a/.github/workflows/build-batch-tuesday.yml
+++ b/.github/workflows/build-batch-tuesday.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate build matrix
         id: generate

--- a/.github/workflows/build-batch-wednesday.yml
+++ b/.github/workflows/build-batch-wednesday.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate build matrix
         id: generate

--- a/.github/workflows/build-git-daily.yml
+++ b/.github/workflows/build-git-daily.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -92,12 +92,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate build matrix
         id: generate-matrix

--- a/.github/workflows/build-new-releases.yml
+++ b/.github/workflows/build-new-releases.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.extract-versions.outputs.has_new_versions == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const newVersions = '${{ steps.extract-versions.outputs.new_versions }}'.split(' ');
@@ -130,10 +130,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -247,7 +247,7 @@ jobs:
 
     steps:
       - name: Comment build results on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const newVersions = '${{ needs.detect-new-releases.outputs.new_versions }}'.split(' ');

--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate inputs
         run: |
@@ -165,7 +165,7 @@ jobs:
           echo "config_file=$CONFIG_FILE" >> $GITHUB_OUTPUT
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -174,11 +174,11 @@ jobs:
           pip install --user pyyaml jinja2 jsonschema
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         if: inputs.push == true && steps.branch-info.outputs.tag_suffix == ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ vars.DOCKER_USERNAME }}
@@ -186,7 +186,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: inputs.push == true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -422,7 +422,7 @@ jobs:
           fi
 
       - name: Upload generated files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-files-${{ inputs.version }}-${{ inputs.distribution }}
           path: |
@@ -445,10 +445,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -457,7 +457,7 @@ jobs:
           pip install --user pyyaml jinja2 jsonschema
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Determine branch and tag suffix
         id: branch-info
@@ -484,7 +484,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: inputs.push == true && steps.branch-info.outputs.tag_suffix == ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ vars.DOCKER_USERNAME }}
@@ -492,14 +492,14 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: inputs.push == true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download generated files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-files-${{ inputs.version }}-${{ inputs.distribution }}
           path: .
@@ -544,7 +544,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -573,7 +573,7 @@ jobs:
 
       - name: Upload digest
         if: steps.build-config.outputs.use_tags == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ inputs.version }}-${{ inputs.distribution }}-${{ contains(matrix.platform, 'amd64') && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -607,7 +607,7 @@ jobs:
 
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Determine branch and tag suffix
         id: branch-info
@@ -634,7 +634,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: inputs.push == true && steps.branch-info.outputs.tag_suffix == ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ vars.DOCKER_USERNAME }}
@@ -642,14 +642,14 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: inputs.push == true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-${{ inputs.version }}-${{ inputs.distribution }}-*

--- a/.github/workflows/discover-releases.yml
+++ b/.github/workflows/discover-releases.yml
@@ -26,18 +26,18 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/test-reusable-action.yml
+++ b/.github/workflows/test-reusable-action.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Test reusable action
         id: test

--- a/.github/workflows/update-readme-versions.yml
+++ b/.github/workflows/update-readme-versions.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/validate-generation.yml
+++ b/.github/workflows/validate-generation.yml
@@ -11,10 +11,10 @@ jobs:
   validate-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
## Why

GitHub is deprecating the **Node.js 20** actions runtime; the workflow suite currently emits `Node.js 20 actions are deprecated` / `the runner ... is too old` warnings. This bumps every JavaScript action to its current latest major - all of which now run on **node24**.

## Bumps (44 pins across 15 files)

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | **v7** |
| actions/setup-python | v4 / v5 | **v6** |
| actions/github-script | v7 | **v9** |
| actions/upload-artifact | v4 | **v7** |
| actions/download-artifact | v4 | **v8** |
| actions/create-github-app-token | v2 | **v3** |
| docker/login-action | v3 | **v4** |
| docker/setup-buildx-action | v3 | **v4** |
| docker/build-push-action | v5 | **v7** |

## Verification

Each bump was checked against this repo's **exact usage** - inputs consumed, outputs referenced, and the load-bearing multi-arch `push-by-digest` + `download-artifact` (`pattern` + `merge-multiple`) manifest-merge flow in `build-single-image.yml`. Findings:

- **No input/output was renamed or removed** for any input this repo uses; **zero YAML adaptations required**.
- `github-script@v9` is ESM-only (no `require('@actions/github')`, cannot redeclare `getOctokit`) - our inline scripts only use the injected `github.rest.*` / `context.*`, so they are unaffected.
- `setup-buildx-action@v4` drops the deprecated `install` input - not used here.
- `create-github-app-token@v3` deprecates `app-id` in favour of `client-id` but `app-id` still works (warning only).
- `actionlint` reports **no remaining node-runtime deprecation warnings** and no new findings.

The docker-based third-party actions (`cbrgm/mastodon-github-action`, `appleboy/telegram-action`) do **not** use the Node runtime and are intentionally left unchanged.

Runtime validation follows from the next scheduled build (and the forky build re-run in the follow-up PR, which exercises `build-single-image.yml` end-to-end).