### PR TITLE
fix(forky): skip BETTER_BACKTRACES on Debian forky (fix experimental build)

### DIFF
--- a/asterisk/23.3.0-forky/build.sh
+++ b/asterisk/23.3.0-forky/build.sh
@@ -52,8 +52,11 @@ log "Configuring Asterisk modules..."
 # Disable BUILD_NATIVE optimization for container builds
 menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
 
-# Enable better backtraces for debugging
-menuselect/menuselect --enable BETTER_BACKTRACES menuselect.makeopts
+# ponytail: BETTER_BACKTRACES left off on Debian forky - its binutils removed the
+# bfd_boolean type from <bfd.h>, so Asterisk's backtrace.c fails to compile. The
+# option is off by default, so omitting --enable is enough. Re-enable for all
+# distros once Asterisk upstream tracks the binutils >= 2.34 bfd API (also revisit
+# when trixie's binutils bumps past 2.33).
 
 # Disable sound packages to reduce image size
 menuselect/menuselect --disable-category MENUSELECT_CORE_SOUNDS menuselect.makeopts
@@ -102,6 +105,8 @@ log "Module configuration completed"
 
 # Pre-build third-party (pjproject) sequentially with verbose output.
 # This surfaces real compiler errors that would otherwise be hidden by parallel make.
+# Skipped on Asterisk < 13: the 'third-party' target was added with bundled
+# pjproject support and does not exist in older trees.
 log "Building third-party dependencies (pjproject) with verbose output..."
 TMPDIR=${TMPDIR} make NOISY_BUILD=yes -j 1 third-party
 

--- a/asterisk/git-forky/build.sh
+++ b/asterisk/git-forky/build.sh
@@ -52,8 +52,11 @@ log "Configuring Asterisk modules..."
 # Disable BUILD_NATIVE optimization for container builds
 menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
 
-# Enable better backtraces for debugging
-menuselect/menuselect --enable BETTER_BACKTRACES menuselect.makeopts
+# ponytail: BETTER_BACKTRACES left off on Debian forky - its binutils removed the
+# bfd_boolean type from <bfd.h>, so Asterisk's backtrace.c fails to compile. The
+# option is off by default, so omitting --enable is enough. Re-enable for all
+# distros once Asterisk upstream tracks the binutils >= 2.34 bfd API (also revisit
+# when trixie's binutils bumps past 2.33).
 
 # Disable sound packages to reduce image size
 menuselect/menuselect --disable-category MENUSELECT_CORE_SOUNDS menuselect.makeopts
@@ -102,6 +105,8 @@ log "Module configuration completed"
 
 # Pre-build third-party (pjproject) sequentially with verbose output.
 # This surfaces real compiler errors that would otherwise be hidden by parallel make.
+# Skipped on Asterisk < 13: the 'third-party' target was added with bundled
+# pjproject support and does not exist in older trees.
 log "Building third-party dependencies (pjproject) with verbose output..."
 TMPDIR=${TMPDIR} make NOISY_BUILD=yes -j 1 third-party
 

--- a/templates/partials/build.sh.j2
+++ b/templates/partials/build.sh.j2
@@ -57,8 +57,16 @@ log "Configuring Asterisk modules..."
 # Disable BUILD_NATIVE optimization for container builds
 menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
 
+{% if config.base.distribution != 'forky' -%}
 # Enable better backtraces for debugging
 menuselect/menuselect --enable BETTER_BACKTRACES menuselect.makeopts
+{% else -%}
+# ponytail: BETTER_BACKTRACES left off on Debian forky - its binutils removed the
+# bfd_boolean type from <bfd.h>, so Asterisk's backtrace.c fails to compile. The
+# option is off by default, so omitting --enable is enough. Re-enable for all
+# distros once Asterisk upstream tracks the binutils >= 2.34 bfd API (also revisit
+# when trixie's binutils bumps past 2.33).
+{% endif %}
 
 # Disable sound packages to reduce image size
 menuselect/menuselect --disable-category MENUSELECT_CORE_SOUNDS menuselect.makeopts


### PR DESCRIPTION
## Problem

The scheduled multi-arch builds fail on the **23.3.0-forky** (experimental Debian forky) image - e.g. [run 28506241093](https://github.com/andrius/asterisk/actions/runs/28506241093), both `linux/amd64` and `linux/arm64`, at the *Build and push by digest* step. Every trixie/bookworm/cert build in the same matrix passes; only forky fails.

## Root cause

Debian **forky**'s `binutils` removed the `bfd_boolean` typedef from `<bfd.h>`. Asterisk's `main/backtrace.c` (compiled only when `BETTER_BACKTRACES` is enabled) still uses the old `bfd_boolean` API, so it fails to compile against forky's newer libbfd - breaking the whole image build.

## Fix

`BETTER_BACKTRACES` is **off by default**, so simply not passing `menuselect --enable BETTER_BACKTRACES` on forky is enough. Gate it by distribution in the build-script template:

```jinja
{% if config.base.distribution != 'forky' -%}
# Enable better backtraces for debugging
menuselect/menuselect --enable BETTER_BACKTRACES menuselect.makeopts
{% else -%}
# BETTER_BACKTRACES left off on Debian forky (binutils dropped bfd_boolean) ...
{% endif %}
```

All other distributions are unchanged (they still enable `BETTER_BACKTRACES`). The two committed forky build scripts (`23.3.0-forky`, `git-forky`) were **regenerated from the template** - verified byte-identical to a fresh `build-asterisk.sh --force-config` regeneration, so they will not drift.

## Verification

- Regeneration is canonical (zero diff on re-render).
- A build-only (`push=false`) forky CI build on this branch is used to confirm the image now compiles end-to-end (also exercises the node24 action bumps from #163).

## Follow-up (out of scope, pre-existing)

Non-forky generated `build.sh` files are missing a *"third-party skip"* comment that already exists in the template (latent drift predating this change) - a repo-wide `regenerate-all-configs.sh` would resolve it in a separate PR.