### PR TITLE
feat(tags): automate semantic-tag promotion and two-phase deprecation

### DIFF
--- a/.github/workflows/discover-releases.yml
+++ b/.github/workflows/discover-releases.yml
@@ -61,6 +61,12 @@ jobs:
           # Generate supported builds YAML from discovered versions
           ./scripts/discover-latest-versions.sh --output-yaml --updates-only
 
+      - name: Promote tags and mark deprecations (PR phase)
+        run: |
+          pip install --user ruamel.yaml
+          python3 scripts/apply-tag-lifecycle.py --phase pr
+          python3 scripts/update-readme-versions.py
+
       - name: Generate config files and Dockerfiles for new versions
         id: generate-configs
         run: |
@@ -266,6 +272,7 @@ jobs:
           git add asterisk/asterisk-releases.yml
           git add asterisk/asterisk-certified-releases.yml
           git add asterisk/supported-asterisk-builds.yml
+          git add README.md
           git add configs/generated/
 
           # Add generated Dockerfiles and build assets for new versions
@@ -336,6 +343,7 @@ jobs:
           PR_BODY="${PR_BODY}- 🔧 Generated YAML config files for new versions\n"
           PR_BODY="${PR_BODY}- 🐳 Generated Dockerfiles and build scripts (build.sh, healthcheck.sh)\n"
           PR_BODY="${PR_BODY}- 🎯 Ready for Docker builds - can trigger build-images workflow\n\n"
+          PR_BODY="${PR_BODY}- 🏷️ Promoted semantic tags to newest release per line; marked superseded versions (deprecation date stamped on merge) - see supported-asterisk-builds.yml diff\n"
 
           PR_BODY="${PR_BODY}### 🎨 Review Checklist\n\n"
           PR_BODY="${PR_BODY}- [ ] Verify all versions are legitimate Asterisk releases\n"

--- a/.github/workflows/finalize-deprecations.yml
+++ b/.github/workflows/finalize-deprecations.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: main-yaml-writer
+  cancel-in-progress: false
+
 jobs:
   finalize:
     runs-on: ubuntu-latest
@@ -29,6 +33,7 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add asterisk/supported-asterisk-builds.yml README.md
             git commit -m "chore(deprecations): finalize deprecated_at on merge [skip ci]"
+            git pull --rebase origin main
             git push
           else
             echo "Nothing pending to finalize."

--- a/.github/workflows/finalize-deprecations.yml
+++ b/.github/workflows/finalize-deprecations.yml
@@ -1,0 +1,35 @@
+# .github/workflows/finalize-deprecations.yml
+name: Finalize Deprecations
+
+on:
+  push:
+    branches: [main]
+    paths: ['asterisk/supported-asterisk-builds.yml']
+
+permissions:
+  contents: write
+
+jobs:
+  finalize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: pip install ruamel.yaml pyyaml
+      - name: Stamp deprecated_at on pending versions
+        run: |
+          python3 scripts/apply-tag-lifecycle.py --phase finalize
+          python3 scripts/update-readme-versions.py
+      - name: Commit if changed
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add asterisk/supported-asterisk-builds.yml README.md
+            git commit -m "chore(deprecations): finalize deprecated_at on merge [skip ci]"
+            git push
+          else
+            echo "Nothing pending to finalize."
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+# .github/workflows/test.yml
+name: Python Tests
+
+on:
+  push:
+    branches: [main]
+    paths: ['lib/**', 'scripts/**', 'tests/**', 'requirements-dev.txt']
+  pull_request:
+    paths: ['lib/**', 'scripts/**', 'tests/**', 'requirements-dev.txt']
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: pip install -r requirements-dev.txt
+      - run: python -m pytest tests/ -q

--- a/.github/workflows/update-readme-versions.yml
+++ b/.github/workflows/update-readme-versions.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: main-yaml-writer
+  cancel-in-progress: false
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest

--- a/lib/tag_lifecycle.py
+++ b/lib/tag_lifecycle.py
@@ -97,6 +97,12 @@ def _lts_major(newest):
     return best
 
 
+def _experimental_members(build):
+    members = build.get("os_matrix") or []
+    return [m for m in members
+            if EXPERIMENTAL_TOKEN in (m.get("additional_tags") or "")]
+
+
 def plan(builds):
     active = _active_parseable(builds)
     lines, newest = _newest_per_line(active)
@@ -114,4 +120,20 @@ def plan(builds):
             if lts is not None and major == lts:
                 tags = ["latest", "stable"] + tags
         p.set_tags[ver] = ",".join(tags)
+
+    for lk, entries in lines.items():
+        keep = newest[lk]["version"]
+        keep_dists = {m.get("distribution")
+                      for m in (newest[lk].get("os_matrix") or [])}
+        for b in entries:
+            ver = b["version"]
+            if ver == keep:
+                continue
+            p.deprecate[ver] = keep
+            if b.get("additional_tags"):
+                p.clear_tags.add(ver)
+            to_move = [m for m in _experimental_members(b)
+                       if m.get("distribution") not in keep_dists]
+            if to_move:
+                p.migrate_experimental.setdefault(keep, []).extend(to_move)
     return p

--- a/lib/tag_lifecycle.py
+++ b/lib/tag_lifecycle.py
@@ -41,3 +41,77 @@ def line_key(version):
     if major == 1:
         return f"{major}.{minor}"
     return str(major)
+
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Plan:
+    set_tags: dict = field(default_factory=dict)            # version -> entry additional_tags
+    clear_tags: set = field(default_factory=set)            # versions to strip entry tags from
+    deprecate: dict = field(default_factory=dict)           # version -> superseded_by
+    migrate_experimental: dict = field(default_factory=dict)  # new_version -> [member dicts]
+
+
+def _is_git(build):
+    v = build.get("version", "")
+    return v == "git" or v.startswith("git-")
+
+
+def _is_active(build):
+    return "os_matrix" in build and not build.get("deprecated_at")
+
+
+def _active_parseable(builds):
+    out = []
+    for b in builds:
+        if _is_git(b) or not _is_active(b):
+            continue
+        try:
+            line_key(b["version"])
+        except (ValueError, KeyError):
+            continue
+        out.append(b)
+    return out
+
+
+def _newest_per_line(active):
+    lines = {}
+    for b in active:
+        lines.setdefault(line_key(b["version"]), []).append(b)
+    newest = {lk: max(entries, key=lambda b: version_sort_key(b["version"]))
+              for lk, entries in lines.items()}
+    return lines, newest
+
+
+def _lts_major(newest):
+    """Highest active even (LTS) *stable* major, or None."""
+    best = None
+    for lk, b in newest.items():
+        if lk.endswith("-cert"):
+            continue
+        major = version_sort_key(b["version"])[0]
+        if major % 2 == 0 and (best is None or major > best):
+            best = major
+    return best
+
+
+def plan(builds):
+    active = _active_parseable(builds)
+    lines, newest = _newest_per_line(active)
+    lts = _lts_major(newest)
+
+    p = Plan()
+    for lk, b in newest.items():
+        ver = b["version"]
+        if lk.endswith("-cert"):
+            tags = [lk]
+        else:
+            major, _minor, _patch, _cert = version_sort_key(ver)
+            bare = lk if major == 1 else str(major)
+            tags = [bare]
+            if lts is not None and major == lts:
+                tags = ["latest", "stable"] + tags
+        p.set_tags[ver] = ",".join(tags)
+    return p

--- a/lib/tag_lifecycle.py
+++ b/lib/tag_lifecycle.py
@@ -136,4 +136,5 @@ def plan(builds):
                        if m.get("distribution") not in keep_dists]
             if to_move:
                 p.migrate_experimental.setdefault(keep, []).extend(to_move)
+                keep_dists.update(m.get("distribution") for m in to_move)
     return p

--- a/lib/tag_lifecycle.py
+++ b/lib/tag_lifecycle.py
@@ -1,0 +1,43 @@
+"""Pure logic for semantic-tag promotion and version deprecation.
+
+No I/O, no clock, no git. Input is the parsed ``latest_builds`` list from
+asterisk/supported-asterisk-builds.yml; output is a Plan (see plan()).
+Spec: docs/superpowers/specs/2026-07-04-tag-lifecycle-design.md
+"""
+from __future__ import annotations
+
+import re
+
+_BASE_RE = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?")
+_CERT_RE = re.compile(r"-cert(\d+)")
+EXPERIMENTAL_TOKEN = "experimental"
+
+
+def version_sort_key(version):
+    """Return (major, minor, patch, cert_number); 'git'/'git-*' -> (999,0,0,0)."""
+    if version == "git" or version.startswith("git-"):
+        return (999, 0, 0, 0)
+    cert = _CERT_RE.search(version)
+    cert_number = int(cert.group(1)) if cert else 0
+    base = version.split("-cert")[0]
+    m = _BASE_RE.match(base)
+    if not m:
+        raise ValueError(f"unparseable version: {version!r}")
+    major = int(m.group(1))
+    minor = int(m.group(2))
+    patch = int(m.group(3)) if m.group(3) else 0
+    return (major, minor, patch, cert_number)
+
+
+def is_cert(version):
+    return "-cert" in version
+
+
+def line_key(version):
+    """Grouping key for tag ownership. Raises ValueError if unparseable."""
+    major, minor, _patch, _cert = version_sort_key(version)
+    if is_cert(version):
+        return f"{major}-cert"
+    if major == 1:
+        return f"{major}.{minor}"
+    return str(major)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.2
+ruamel.yaml==0.18.10

--- a/scripts/apply-tag-lifecycle.py
+++ b/scripts/apply-tag-lifecycle.py
@@ -13,6 +13,7 @@ import argparse
 import copy
 import os
 import sys
+from datetime import datetime, timezone
 
 from ruamel.yaml import YAML
 
@@ -55,6 +56,15 @@ def apply_pr(data):
             target.append(copy.deepcopy(member))
 
 
+def finalize(data, now_iso):
+    stamped = []
+    for b in data["latest_builds"]:
+        if b.get("superseded_by") and not b.get("deprecated_at"):
+            b["deprecated_at"] = now_iso
+            stamped.append(b["version"])
+    return stamped
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--phase", required=True, choices=["pr", "finalize"])
@@ -68,7 +78,9 @@ def main(argv=None):
     if args.phase == "pr":
         apply_pr(data)
     else:
-        raise SystemExit("finalize implemented in a later task")
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        stamped = finalize(data, now_iso)
+        print(f"finalized: {stamped}")
 
     with open(args.file, "w") as fh:
         y.dump(data, fh)

--- a/scripts/apply-tag-lifecycle.py
+++ b/scripts/apply-tag-lifecycle.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import io
 import os
 import sys
 from datetime import datetime, timezone
@@ -65,26 +66,44 @@ def finalize(data, now_iso):
     return stamped
 
 
+def _render(y, data):
+    buf = io.StringIO()
+    y.dump(data, buf)
+    return buf.getvalue()
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--phase", required=True, choices=["pr", "finalize"])
     ap.add_argument("--file", default=DEFAULT_FILE)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--check", action="store_true")
     args = ap.parse_args(argv)
 
     y = _yaml()
     with open(args.file) as fh:
-        data = y.load(fh)
+        original = fh.read()
+    data = y.load(original)
 
     if args.phase == "pr":
         apply_pr(data)
     else:
         now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        stamped = finalize(data, now_iso)
-        print(f"finalized: {stamped}")
+        print(f"finalized: {finalize(data, now_iso)}")
 
+    rendered = _render(y, data)
+    if args.check:
+        changed = rendered != original
+        if changed:
+            print("DRIFT: supported-asterisk-builds.yml is not in desired state")
+        return 1 if changed else 0
+    if args.dry_run:
+        print(rendered)
+        return 0
     with open(args.file, "w") as fh:
-        y.dump(data, fh)
+        fh.write(rendered)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/apply-tag-lifecycle.py
+++ b/scripts/apply-tag-lifecycle.py
@@ -17,6 +17,7 @@ import sys
 from datetime import datetime, timezone
 
 from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from lib.tag_lifecycle import plan  # noqa: E402
@@ -46,11 +47,11 @@ def apply_pr(data):
     index = _by_version(data)
 
     for ver, tags in p.set_tags.items():
-        index[ver]["additional_tags"] = tags
+        index[ver]["additional_tags"] = DoubleQuotedScalarString(tags)
     for ver in p.clear_tags:
         index[ver].pop("additional_tags", None)
     for ver, superseded_by in p.deprecate.items():
-        index[ver]["superseded_by"] = superseded_by
+        index[ver]["superseded_by"] = DoubleQuotedScalarString(superseded_by)
     for new_ver, members in p.migrate_experimental.items():
         target = index[new_ver].setdefault("os_matrix", [])
         for member in members:
@@ -61,7 +62,7 @@ def finalize(data, now_iso):
     stamped = []
     for b in data["latest_builds"]:
         if b.get("superseded_by") and not b.get("deprecated_at"):
-            b["deprecated_at"] = now_iso
+            b["deprecated_at"] = DoubleQuotedScalarString(now_iso)
             stamped.append(b["version"])
     return stamped
 

--- a/scripts/apply-tag-lifecycle.py
+++ b/scripts/apply-tag-lifecycle.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# scripts/apply-tag-lifecycle.py
+"""Apply tag-lifecycle plan to supported-asterisk-builds.yml.
+
+Phases:
+  pr        - move tags, set superseded_by (no deprecated_at), migrate experimental
+  finalize  - stamp deprecated_at on entries pending deprecation (Task 5)
+Round-trips YAML with ruamel to preserve comments/order/quotes.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import sys
+
+from ruamel.yaml import YAML
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from lib.tag_lifecycle import plan  # noqa: E402
+
+DEFAULT_FILE = os.path.join(os.path.dirname(__file__), "..",
+                            "asterisk", "supported-asterisk-builds.yml")
+
+
+def _yaml():
+    y = YAML()
+    y.preserve_quotes = True
+    y.width = 4096  # avoid line-wrapping long values
+    # Match the repo's indented block-sequence style (dash indented under its
+    # key) so a no-op round-trip of supported-asterisk-builds.yml is
+    # byte-stable and real edits produce minimal PR diffs.
+    y.indent(mapping=2, sequence=4, offset=2)
+    return y
+
+
+def _by_version(data):
+    return {b["version"]: b for b in data["latest_builds"]}
+
+
+def apply_pr(data):
+    builds = list(data["latest_builds"])
+    p = plan(builds)
+    index = _by_version(data)
+
+    for ver, tags in p.set_tags.items():
+        index[ver]["additional_tags"] = tags
+    for ver in p.clear_tags:
+        index[ver].pop("additional_tags", None)
+    for ver, superseded_by in p.deprecate.items():
+        index[ver]["superseded_by"] = superseded_by
+    for new_ver, members in p.migrate_experimental.items():
+        target = index[new_ver].setdefault("os_matrix", [])
+        for member in members:
+            target.append(copy.deepcopy(member))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--phase", required=True, choices=["pr", "finalize"])
+    ap.add_argument("--file", default=DEFAULT_FILE)
+    args = ap.parse_args(argv)
+
+    y = _yaml()
+    with open(args.file) as fh:
+        data = y.load(fh)
+
+    if args.phase == "pr":
+        apply_pr(data)
+    else:
+        raise SystemExit("finalize implemented in a later task")
+
+    with open(args.file, "w") as fh:
+        y.dump(data, fh)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_apply_tag_lifecycle.py
+++ b/tests/test_apply_tag_lifecycle.py
@@ -127,3 +127,21 @@ def test_finalize_idempotent():
     atl.finalize(data, "2026-07-04T11:00:00Z")
     stamped_again = atl.finalize(data, "2026-07-05T11:00:00Z")
     assert stamped_again == []   # nothing pending on second run
+
+
+def test_check_returns_nonzero_when_drift(tmp_path):
+    f = tmp_path / "b.yml"
+    f.write_text(YAML_IN)
+    rc = atl.main(["--phase", "pr", "--file", str(f), "--check"])
+    assert rc == 1                      # YAML_IN is not in desired state
+    assert f.read_text() == YAML_IN     # unchanged
+
+
+def test_check_returns_zero_when_clean(tmp_path):
+    f = tmp_path / "b.yml"
+    f.write_text(YAML_IN)
+    atl.main(["--phase", "pr", "--file", str(f)])   # bring to desired state
+    settled = f.read_text()
+    rc = atl.main(["--phase", "pr", "--file", str(f), "--check"])
+    assert rc == 0
+    assert f.read_text() == settled

--- a/tests/test_apply_tag_lifecycle.py
+++ b/tests/test_apply_tag_lifecycle.py
@@ -145,3 +145,20 @@ def test_check_returns_zero_when_clean(tmp_path):
     rc = atl.main(["--phase", "pr", "--file", str(f), "--check"])
     assert rc == 0
     assert f.read_text() == settled
+
+
+def test_apply_pr_double_quotes_fresh_keys():
+    import io
+    y, data = _load(YAML_IN)
+    atl.apply_pr(data)
+    buf = io.StringIO(); y.dump(data, buf); out = buf.getvalue()
+    assert 'additional_tags: "23"' in out       # fresh entry-level tag on 23.4.1
+    assert 'superseded_by: "23.4.1"' in out      # fresh key on 23.3.0
+
+
+def test_finalize_double_quotes_deprecated_at():
+    import io
+    y, data = _load(PENDING_YAML)
+    atl.finalize(data, "2026-07-04T11:00:00Z")
+    buf = io.StringIO(); y.dump(data, buf)
+    assert 'deprecated_at: "2026-07-04T11:00:00Z"' in buf.getvalue()

--- a/tests/test_apply_tag_lifecycle.py
+++ b/tests/test_apply_tag_lifecycle.py
@@ -90,3 +90,40 @@ def test_yaml_roundtrip_preserves_indented_sequence_style():
     buf = io.StringIO()
     y.dump(data, buf)
     assert buf.getvalue() == INDENTED_YAML
+
+
+PENDING_YAML = """\
+latest_builds:
+  - version: "23.3.0"
+    superseded_by: "23.4.1"
+    os_matrix:
+      - {os: "debian", distribution: "trixie", architectures: ["amd64"]}
+  - version: "22.8.2"
+    superseded_by: "22.9.0"
+    deprecated_at: "2026-05-04T07:22:53Z"
+    os_matrix:
+      - {os: "debian", distribution: "trixie", architectures: ["amd64"]}
+  - version: "23.4.1"
+    additional_tags: "23"
+    os_matrix:
+      - {os: "debian", distribution: "trixie", architectures: ["amd64"]}
+metadata:
+  mode: "manual"
+"""
+
+
+def test_finalize_stamps_only_pending():
+    y, data = _load(PENDING_YAML)
+    stamped = atl.finalize(data, "2026-07-04T11:00:00Z")
+    builds = {b["version"]: b for b in data["latest_builds"]}
+    assert stamped == ["23.3.0"]
+    assert builds["23.3.0"]["deprecated_at"] == "2026-07-04T11:00:00Z"
+    # already-deprecated one is untouched (keeps original date)
+    assert builds["22.8.2"]["deprecated_at"] == "2026-05-04T07:22:53Z"
+
+
+def test_finalize_idempotent():
+    y, data = _load(PENDING_YAML)
+    atl.finalize(data, "2026-07-04T11:00:00Z")
+    stamped_again = atl.finalize(data, "2026-07-05T11:00:00Z")
+    assert stamped_again == []   # nothing pending on second run

--- a/tests/test_apply_tag_lifecycle.py
+++ b/tests/test_apply_tag_lifecycle.py
@@ -1,0 +1,92 @@
+import sys, os, importlib.util
+from ruamel.yaml import YAML
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, ROOT)
+_spec = importlib.util.spec_from_file_location(
+    "apply_tag_lifecycle", os.path.join(ROOT, "scripts", "apply-tag-lifecycle.py"))
+atl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(atl)
+
+YAML_IN = """\
+# header comment must survive
+latest_builds:
+  - version: "23.3.0"
+    additional_tags: "23"
+    os_matrix:
+      - os: "debian"
+        distribution: "trixie"
+        architectures: ["amd64", "arm64"]
+      - os: "debian"
+        distribution: "forky"
+        architectures: ["amd64", "arm64"]
+        additional_tags: "experimental"
+  - version: "23.4.1"
+    os_matrix:
+      - os: "debian"
+        distribution: "trixie"
+        architectures: ["amd64", "arm64"]
+metadata:
+  mode: "manual"
+"""
+
+
+def _load(text):
+    y = YAML()
+    y.preserve_quotes = True
+    return y, y.load(text)
+
+
+def test_apply_pr_moves_tag_sets_superseded_migrates_forky(tmp_path):
+    y, data = _load(YAML_IN)
+    atl.apply_pr(data)
+    builds = {b["version"]: b for b in data["latest_builds"]}
+    # tag moved to newest, cleared from old
+    assert builds["23.4.1"]["additional_tags"] == "23"
+    assert "additional_tags" not in builds["23.3.0"]
+    # pending deprecation: superseded_by set, NO deprecated_at yet
+    assert builds["23.3.0"]["superseded_by"] == "23.4.1"
+    assert "deprecated_at" not in builds["23.3.0"]
+    # forky migrated onto 23.4.1
+    dists = [m["distribution"] for m in builds["23.4.1"]["os_matrix"]]
+    assert "forky" in dists
+    forky = [m for m in builds["23.4.1"]["os_matrix"] if m["distribution"] == "forky"][0]
+    assert forky["additional_tags"] == "experimental"
+
+
+def test_apply_pr_preserves_header_comment(tmp_path):
+    import io
+    y, data = _load(YAML_IN)
+    atl.apply_pr(data)
+    buf = io.StringIO()
+    y.dump(data, buf)
+    assert "# header comment must survive" in buf.getvalue()
+
+
+# Byte-stability guard: the real supported-asterisk-builds.yml uses indented
+# block sequences (dash indented under its key). _yaml() must round-trip that
+# style byte-for-byte with NO changes, or every real run produces a huge noisy
+# diff. This fixture is in that exact canonical style.
+INDENTED_YAML = (
+    "# header\n"
+    "latest_builds:\n"
+    '  - version: "22.10.1"\n'
+    '    additional_tags: "latest,stable,22"\n'
+    "    os_matrix:\n"
+    '      - os: "debian"\n'
+    '        distribution: "trixie"\n'
+    "        architectures:\n"
+    '          - "amd64"\n'
+    '          - "arm64"\n'
+    "metadata:\n"
+    '  mode: "manual"\n'
+)
+
+
+def test_yaml_roundtrip_preserves_indented_sequence_style():
+    import io
+    y = atl._yaml()
+    data = y.load(INDENTED_YAML)
+    buf = io.StringIO()
+    y.dump(data, buf)
+    assert buf.getvalue() == INDENTED_YAML

--- a/tests/test_tag_lifecycle.py
+++ b/tests/test_tag_lifecycle.py
@@ -121,3 +121,61 @@ def test_set_tags_skips_deprecated_and_unparseable():
     p = plan(builds)
     assert p.set_tags["22.10.1"] == "latest,stable,22"
     assert "garbage" not in p.set_tags
+
+
+def _b_forky(version, tags=None):
+    entry = _b(version, tags)
+    entry["os_matrix"].append({"os": "debian", "distribution": "forky",
+                               "architectures": ["amd64", "arm64"],
+                               "additional_tags": "experimental"})
+    return entry
+
+
+def test_deprecate_all_older_active_in_line():
+    builds = [_b("22.7.0"), _b("22.9.0", "latest,stable,22"), _b("22.10.1")]
+    p = plan(builds)
+    assert p.deprecate == {"22.7.0": "22.10.1", "22.9.0": "22.10.1"}
+    assert "22.9.0" in p.clear_tags      # it held tags
+    assert "22.7.0" not in p.clear_tags  # it had none
+
+
+def test_single_entry_line_not_deprecated():
+    builds = [_b("18.9-cert18", "18-cert"), _b("22.10.1")]
+    p = plan(builds)
+    assert "18.9-cert18" not in p.deprecate
+
+
+def test_experimental_member_migrated_to_newest():
+    builds = [_b_forky("23.3.0", "23"), _b("23.4.1")]
+    p = plan(builds)
+    assert p.deprecate["23.3.0"] == "23.4.1"
+    moved = p.migrate_experimental["23.4.1"]
+    assert len(moved) == 1
+    assert moved[0]["distribution"] == "forky"
+    assert moved[0]["additional_tags"] == "experimental"
+
+
+def test_experimental_not_migrated_if_target_has_distribution():
+    newest = _b_forky("23.4.1")          # already has forky
+    builds = [_b_forky("23.3.0", "23"), newest]
+    p = plan(builds)
+    assert "23.4.1" not in p.migrate_experimental
+
+
+def test_plan_idempotent_after_apply():
+    # simulate applied state: newest has tags, old is deprecated + forky moved
+    applied = [
+        {"version": "23.3.0", "additional_tags": "23",
+         "deprecated_at": "2026-07-04T00:00:00Z", "superseded_by": "23.4.1",
+         "os_matrix": [{"distribution": "trixie", "architectures": ["amd64"]},
+                       {"distribution": "forky", "architectures": ["amd64"],
+                        "additional_tags": "experimental"}]},
+        {"version": "23.4.1", "additional_tags": "23",
+         "os_matrix": [{"distribution": "trixie", "architectures": ["amd64"]},
+                       {"distribution": "forky", "architectures": ["amd64"],
+                        "additional_tags": "experimental"}]},
+    ]
+    p = plan(applied)
+    assert p.deprecate == {}                 # 23.3.0 already deprecated -> excluded
+    assert p.migrate_experimental == {}
+    assert p.set_tags == {"23.4.1": "23"}    # unchanged

--- a/tests/test_tag_lifecycle.py
+++ b/tests/test_tag_lifecycle.py
@@ -1,0 +1,44 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import pytest
+from lib.tag_lifecycle import version_sort_key, is_cert, line_key
+
+
+def test_version_sort_key_stable():
+    assert version_sort_key("22.10.1") == (22, 10, 1, 0)
+    assert version_sort_key("20.19.0") == (20, 19, 0, 0)
+    assert version_sort_key("1.8.32.3") == (1, 8, 32, 0)
+
+
+def test_version_sort_key_cert():
+    assert version_sort_key("20.7-cert11") == (20, 7, 0, 11)
+    assert version_sort_key("22.8-cert3") == (22, 8, 0, 3)
+
+
+def test_version_sort_key_git_highest():
+    assert version_sort_key("git") == (999, 0, 0, 0)
+    assert version_sort_key("git-forky") == (999, 0, 0, 0)
+
+
+def test_version_sort_key_orders_cert_numerically():
+    assert version_sort_key("20.7-cert11") > version_sort_key("20.7-cert10")
+
+
+def test_version_sort_key_raises_on_garbage():
+    with pytest.raises(ValueError):
+        version_sort_key("not-a-version")
+
+
+def test_is_cert():
+    assert is_cert("20.7-cert11") is True
+    assert is_cert("22.10.1") is False
+
+
+def test_line_key():
+    assert line_key("22.10.1") == "22"
+    assert line_key("23.4.1") == "23"
+    assert line_key("20.7-cert11") == "20-cert"   # major only
+    assert line_key("22.8-cert3") == "22-cert"
+    assert line_key("1.8.32.3") == "1.8"          # legacy: major.minor
+    assert line_key("1.2.40") == "1.2"
+    assert line_key("10.12.4") == "10"

--- a/tests/test_tag_lifecycle.py
+++ b/tests/test_tag_lifecycle.py
@@ -42,3 +42,82 @@ def test_line_key():
     assert line_key("1.8.32.3") == "1.8"          # legacy: major.minor
     assert line_key("1.2.40") == "1.2"
     assert line_key("10.12.4") == "10"
+
+
+from lib.tag_lifecycle import plan, Plan
+
+
+def _b(version, tags=None, os_matrix=True, deprecated_at=None):
+    entry = {"version": version}
+    if tags is not None:
+        entry["additional_tags"] = tags
+    if os_matrix:
+        entry["os_matrix"] = [{"os": "debian", "distribution": "trixie",
+                               "architectures": ["amd64", "arm64"]}]
+    if deprecated_at:
+        entry["deprecated_at"] = deprecated_at
+    return entry
+
+
+def test_set_tags_latest_stable_on_newest_even_lts():
+    builds = [_b("22.9.0", "latest,stable,22"), _b("22.10.1"),
+              _b("23.3.0", "23"), _b("23.4.1")]
+    p = plan(builds)
+    assert p.set_tags["22.10.1"] == "latest,stable,22"   # 22 = newest even LTS
+    assert p.set_tags["23.4.1"] == "23"                  # 23 odd -> bare major only
+    assert "22.9.0" not in p.set_tags
+    assert "23.3.0" not in p.set_tags
+
+
+def test_set_tags_bare_major_for_non_top_lts():
+    builds = [_b("20.19.0", "20"), _b("20.20.1"), _b("22.10.1", "latest,stable,22")]
+    p = plan(builds)
+    assert p.set_tags["20.20.1"] == "20"                 # 20 even but < 22
+    assert p.set_tags["22.10.1"] == "latest,stable,22"
+
+
+def test_set_tags_cert_line_isolated():
+    # 22 is the newest even LTS -> gets latest/stable; the 20 stable line gets
+    # bare "20"; the 20-cert line gets "20-cert". Cert line never leaks into "20".
+    builds = [_b("20.7-cert10", "20-cert"), _b("20.7-cert11"),
+              _b("20.20.1", "20"), _b("22.10.1", "latest,stable,22")]
+    p = plan(builds)
+    assert p.set_tags["20.7-cert11"] == "20-cert"
+    assert p.set_tags["20.20.1"] == "20"
+    assert p.set_tags["22.10.1"] == "latest,stable,22"
+
+
+def test_lts_major_with_cert_counterpart_still_gets_latest_stable():
+    # Real-data shape: the LTS major (22) has BOTH a stable line and a cert line.
+    # latest/stable must ride the stable line; the cert counterpart must not
+    # suppress it. (Regression guard: an earlier impl wrongly excluded any major
+    # that had a cert line, which pushed latest/stable onto an ancient even major.)
+    builds = [_b("22.10.1"), _b("22.8-cert3", "22-cert"),
+              _b("20.20.1", "20"), _b("20.7-cert11", "20-cert")]
+    p = plan(builds)
+    assert p.set_tags["22.10.1"] == "latest,stable,22"
+    assert p.set_tags["22.8-cert3"] == "22-cert"
+    assert p.set_tags["20.20.1"] == "20"
+
+
+def test_set_tags_git_ignored():
+    builds = [{"version": "git", "additional_tags": "testing,dev",
+               "os_matrix": [{"distribution": "trixie", "architectures": ["amd64"]}]},
+              _b("22.10.1")]
+    p = plan(builds)
+    assert "git" not in p.set_tags
+
+
+def test_set_tags_legacy_lines_separate():
+    builds = [_b("1.2.40", "1.2"), _b("1.8.32.3", "1.8"), _b("22.10.1")]
+    p = plan(builds)
+    assert p.set_tags["1.2.40"] == "1.2"
+    assert p.set_tags["1.8.32.3"] == "1.8"
+
+
+def test_set_tags_skips_deprecated_and_unparseable():
+    builds = [_b("22.9.0", "latest,stable,22", deprecated_at="2026-05-04T07:22:53Z"),
+              _b("22.10.1"), _b("garbage")]
+    p = plan(builds)
+    assert p.set_tags["22.10.1"] == "latest,stable,22"
+    assert "garbage" not in p.set_tags

--- a/tests/test_tag_lifecycle.py
+++ b/tests/test_tag_lifecycle.py
@@ -179,3 +179,10 @@ def test_plan_idempotent_after_apply():
     assert p.deprecate == {}                 # 23.3.0 already deprecated -> excluded
     assert p.migrate_experimental == {}
     assert p.set_tags == {"23.4.1": "23"}    # unchanged
+
+
+def test_experimental_deduped_across_multiple_superseded():
+    # two older entries in one line both carry a forky member; only ONE migrates
+    p = plan([_b_forky("23.2.0", "23"), _b_forky("23.3.0", "23"), _b("23.4.1")])
+    moved = p.migrate_experimental["23.4.1"]
+    assert len([m for m in moved if m["distribution"] == "forky"]) == 1


### PR DESCRIPTION
## Summary

Automates semantic Docker tag promotion and version deprecation from `asterisk/supported-asterisk-builds.yml`, so new Asterisk releases claim their tags and supersede old ones without manual YAML edits.

- **Tag promotion:** the newest release per version-line receives its semantic tags. `latest` + `stable` ride the newest active **even (LTS)** stable-line major (22 today), never the higher odd major (23). Cert lines get `<major>-cert`; legacy `1.x` lines get `<major>.<minor>`; frozen majors keep their bare `<major>`.
- **Two-phase deprecation:** the PR phase sets `superseded_by` (no date, versions stay buildable during review); merge stamps `deprecated_at`. `generate-build-matrix` already excludes any entry with `deprecated_at`, so deprecation simply stops building/pushing - images and tags are never deleted.
- **Experimental handling:** experimental (`forky`) members keep their member-level `additional_tags: "experimental"` and never inherit a stable/major tag. When a new release supersedes the entry carrying a forky member, that member is migrated forward verbatim.

## What's in here

- `lib/tag_lifecycle.py` - pure logic (`version_sort_key`, `line_key`, `plan(builds) -> Plan`); no I/O, no clock.
- `scripts/apply-tag-lifecycle.py` - ruamel round-trip CLI with `--phase pr` / `--phase finalize`, plus `--check` (drift guard) and `--dry-run`. Round-trip is byte-stable for a no-op edit (minimal diffs).
- `.github/workflows/test.yml` - runs the pytest suite on `lib`/`scripts`/`tests` changes.
- `.github/workflows/discover-releases.yml` - runs `--phase pr` + README regen before config generation (so a migrated forky member gets its configs), stages `README.md`, and notes the changes in the PR body.
- `.github/workflows/finalize-deprecations.yml` - stamps `deprecated_at` on merge with `[skip ci]`, serialized against the README workflow via a shared `concurrency` group + rebase-before-push.

## Testing

29 pytest tests (pure logic + CLI), all passing. Validated end-to-end against the current real `supported-asterisk-builds.yml` (dry-run, read-only): `22.10.1 -> latest,stable,22`, `23.4.1 -> 23`, `20.20.1 -> 20`, `21.12.3 -> 21`, `20.7-cert11 -> 20-cert`, `22.8-cert3 -> 22-cert`; six predecessors marked `superseded_by`; forky migrated `23.3.0 -> 23.4.1` keeping `experimental`. Idempotent on re-run.

## After merge (one-time)

Run the backfill once **before** the next scheduled discovery run: apply the rules to today's drift, then trigger targeted `build-images.yml` dispatches (`push=true`) for the six versions whose tags move, so the registry tags actually repoint (those versions already exist, so nothing rebuilds them automatically). After that, discovery (PR phase) and finalize (merge phase) keep tags current on their own.
