### PR TITLE
fix(alpine): compute the tag lattice on the local build path

### DIFF
--- a/scripts/build-asterisk.sh
+++ b/scripts/build-asterisk.sh
@@ -297,6 +297,9 @@ import yaml
 import sys
 import os
 
+sys.path.insert(0, '${PROJECT_DIR}/lib')
+from alpine_tags import alpine_tags  # Alpine legs publish the tag lattice, not the version-level tags
+
 def log_info(msg):
     print(f"\033[0;34m[INFO]\033[0m  {msg}", file=sys.stderr)
 
@@ -375,6 +378,11 @@ try:
     additional_tags = version_data.get('additional_tags', '')
     log_debug(f"Additional tags for version $version: {additional_tags}")
 
+    # The version-level 'latest' tag marks the LTS latest-owner; the Alpine
+    # lattice mirrors it as the 'alpine'/'stable-alpine' aliases. Computed once
+    # here (version level), never per-member (mirrors generate-build-matrix).
+    owns_latest = 'latest' in additional_tags
+
     # Handle different os_matrix formats (list or single entry)
     if isinstance(os_matrix, list):
         matrix_list = os_matrix
@@ -404,12 +412,27 @@ try:
 
         # Only add build entry if we have architectures after filtering
         if filtered_architectures:
+            # Debian members keep the version-level tags (unchanged). Alpine
+            # members REPLACE them with the computed tag lattice - an inherited
+            # bare 'latest' would race the Debian image for that tag (mirrors
+            # .github/actions/generate-build-matrix, plan 003 section 6).
+            entry_tags = additional_tags
+            if os_name == 'alpine':
+                alpine_role = matrix_entry.get('alpine_role') or (
+                    'edge' if distribution == 'edge' else 'stable')
+                entry_tags = ','.join(alpine_tags(
+                    version="$version",
+                    apk_version=matrix_entry.get('apk_version', ''),
+                    alpine_version=distribution,
+                    alpine_role=alpine_role,
+                    owns_latest=owns_latest,
+                ))
             builds.append({
                 'os': os_name,
                 'distribution': distribution,
                 'architectures': filtered_architectures,  # Changed: now array of architectures
                 'template': template,  # Include template field
-                'additional_tags': additional_tags,  # Include additional_tags
+                'additional_tags': entry_tags,  # Alpine: lattice; Debian: version-level
                 'source': 'custom_matrix'
             })
 

--- a/tests/test_build_matrix_alpine_tags.py
+++ b/tests/test_build_matrix_alpine_tags.py
@@ -1,0 +1,118 @@
+"""Local build path emits the Alpine tag lattice, not the version-level tags.
+
+Regression test for the tag-lattice inheritance gap in build-asterisk.sh's
+embedded get_build_matrix(): before the fix an Alpine build leg inherited the
+Debian/semantic version-level tags (latest, stable, 22, bare 22.10.1) and, on
+--push, collided with the Debian image for those tags. The CI matrix generator
+(.github/actions/generate-build-matrix) already REPLACES an Alpine member's
+tags with lib/alpine_tags.py's lattice; this pins that the LOCAL path does the
+same, while Debian members keep their version-level tags byte-for-byte.
+
+Style mirrors tests/test_golden_regeneration.py: build-asterisk.sh --dry-run
+runs inside a throwaway git worktree so generated files are never written into
+the developer's working tree. The working-tree copy of the script is staged
+into the worktree first, so the test exercises uncommitted edits too.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+
+import pytest
+
+# Repo root is one level up from tests/ (this checkout is itself a worktree).
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# One "Build targets" line: "  -> os/distribution (archs) [additional_tags: T] [from: src]"
+_TARGET = re.compile(
+    r"→\s+(?P<os>\S+?)/(?P<dist>\S+?)\s+\([^)]*\).*?"
+    r"\[additional_tags:\s*(?P<tags>[^\]]*)\]"
+)
+
+_CACHE = {}
+
+
+@pytest.fixture(scope="module")
+def worktree(tmp_path_factory):
+    """A throwaway detached worktree of HEAD, carrying the working-tree script."""
+    wt = tmp_path_factory.mktemp("alpine_tags") / "wt"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(wt)],
+        check=True, cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    # Exercise the working-tree script (may carry uncommitted edits), not HEAD.
+    shutil.copy2(
+        os.path.join(REPO_ROOT, "scripts", "build-asterisk.sh"),
+        os.path.join(str(wt), "scripts", "build-asterisk.sh"),
+    )
+    yield str(wt)
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(wt)],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+
+
+def _tags_by_leg(worktree, version):
+    """Map (os, distribution) -> emitted additional_tags list for a --dry-run."""
+    if version in _CACHE:
+        return _CACHE[version]
+    run = subprocess.run(
+        ["./scripts/build-asterisk.sh", version, "--dry-run", "--skip-format-dockerfile"],
+        cwd=worktree, capture_output=True, text=True,
+    )
+    assert run.returncode == 0, (
+        f"{version}: dry-run failed (rc={run.returncode})\n"
+        f"stderr:\n{run.stderr[-2000:]}"
+    )
+    legs = {}
+    for line in _ANSI.sub("", run.stdout).splitlines():
+        m = _TARGET.search(line)
+        if m:
+            legs[(m.group("os"), m.group("dist"))] = [
+                t for t in m.group("tags").split(",") if t
+            ]
+    _CACHE[version] = legs
+    return legs
+
+
+class TestAlpineLegEmitsLattice:
+    """Given an Alpine leg of 22.10.1, it publishes the suffixed tag lattice."""
+
+    def test_stable_leg_carries_suffixed_lattice_not_bare_tags(self, worktree):
+        alpine_324 = _tags_by_leg(worktree, "22.10.1")[("alpine", "3.24")]
+
+        # Suffixed lattice is present: implicit line tag + explicit version tag.
+        assert "22-alpine" in alpine_324
+        assert "22.10.1-alpine-3.24" in alpine_324
+
+        # The inherited Debian/semantic bare tags must NOT leak in. Token-exact
+        # membership, so 'stable-alpine' never false-positives a bare 'stable'.
+        for bare in ("latest", "stable", "22", "22.10.1"):
+            assert bare not in alpine_324, f"bare {bare!r} leaked into {alpine_324}"
+
+    def test_edge_leg_is_explicit_only(self, worktree):
+        alpine_edge = _tags_by_leg(worktree, "22.10.1")[("alpine", "edge")]
+        assert "22.10.1-alpine-edge" in alpine_edge
+        # edge is not the stable tree: the implicit '22-alpine' must be absent.
+        assert "22-alpine" not in alpine_edge
+
+
+class TestDebianLegKeepsVersionTags:
+    """Debian legs are untouched by the Alpine fix (tags stay byte-identical)."""
+
+    def test_trixie_keeps_version_level_tags(self, worktree):
+        assert _tags_by_leg(worktree, "22.10.1")[("debian", "trixie")] == [
+            "latest", "stable", "22",
+        ]
+
+    def test_forky_leg_unchanged_and_alpine_still_lattice(self, worktree):
+        # Guards the design trap: the local path must NOT adopt per-member tags,
+        # so 23.4.1's forky leg stays '23' (its member-level 'experimental' tag
+        # is a pre-existing, separate concern - out of scope for this fix).
+        legs = _tags_by_leg(worktree, "23.4.1")
+        assert legs[("debian", "trixie")] == ["23"]
+        assert legs[("debian", "forky")] == ["23"]
+        # ...while the Alpine legs of the same version carry the lattice.
+        assert "23.4.1-alpine-3.24" in legs[("alpine", "3.24")]


### PR DESCRIPTION
## Compute the Alpine tag lattice on the local build path

`get_build_matrix()` in `scripts/build-asterisk.sh` read `additional_tags` once
at the **version level** and stamped that same value onto every `os_matrix`
member, Alpine included. So a manual `./scripts/build-asterisk.sh <v> --push`
would tag an Alpine image with the Debian/semantic tags (`latest`, `stable`,
`<major>`, bare `<v>`) and **collide with the Debian manifest** for those tags.
The CI path was already correct - `.github/actions/generate-build-matrix`
computes the lattice via `lib/alpine_tags.py` and replaces an Alpine member's
inherited tags - but `alpine_tags()` had **no consumer on the local path**.

### Fix

Mirror the CI matrix generator inside `get_build_matrix()`:

- import `alpine_tags` via an **absolute** `${PROJECT_DIR}/lib` path (the script
  never `cd`s to the repo root, so the CI reference's relative `'lib'` would
  `ModuleNotFoundError` from any other cwd and break even the Debian path);
- compute `owns_latest` **once** at the version level, never per member;
- for `os == 'alpine'` **only**, replace the leg's tags with the computed
  lattice. Debian legs keep their version-level tags **byte-for-byte**.

The per-member override the CI reference also applies to Debian was deliberately
**not** adopted here: it would silently flip 23.4.1's/23.3.0's `forky` leg to
`experimental` and break the Debian-byte-identical guard (goldens are file-level
and would not catch it). That is a separate, pre-existing same-class bug for the
Debian forky leg, tracked in the backlog - out of scope for this change.

### Tests

`tests/test_build_matrix_alpine_tags.py` (new, 4 tests) runs `--dry-run` in a
throwaway git worktree (same pattern as `test_golden_regeneration.py`, so no
generated files are written into the working tree) and asserts **token-exact**
membership (splitting the CSV) so `stable-alpine` never false-positives a bare
`stable`:

- Alpine `3.24` leg of 22.10.1 carries `22-alpine` + `22.10.1-alpine-3.24` and
  none of the bare `latest`/`stable`/`22`/`22.10.1`;
- Alpine `edge` leg carries `22.10.1-alpine-edge` but **not** the implicit
  `22-alpine` (edge is not the stable tree);
- Debian `trixie` leg of 22.10.1 stays `latest,stable,22`;
- 23.4.1 `trixie` **and** `forky` legs stay `23` (guards the forky trap above),
  while the Alpine leg carries the lattice.

### Verification

- `python3 -m pytest tests/` → **112 passed** (108 baseline + 4 new), including
  all 9 golden-regeneration tests (Debian output byte-identical; the change
  touches only tag emission, not generated files).
- No files under `asterisk/` or `configs/generated/` change.
