### PR TITLE
fix(build): honor per-member additional_tags on the local build path

### DIFF
--- a/scripts/build-asterisk.sh
+++ b/scripts/build-asterisk.sh
@@ -412,11 +412,13 @@ try:
 
         # Only add build entry if we have architectures after filtering
         if filtered_architectures:
-            # Debian members keep the version-level tags (unchanged). Alpine
-            # members REPLACE them with the computed tag lattice - an inherited
-            # bare 'latest' would race the Debian image for that tag (mirrors
-            # .github/actions/generate-build-matrix, plan 003 section 6).
-            entry_tags = additional_tags
+            # Per-member additional_tags override the version-level default
+            # (e.g. forky's 'experimental'); members without the key keep the
+            # version-level tags (mirrors .github/actions/generate-build-matrix
+            # line 128). Alpine members REPLACE entry_tags with the computed tag
+            # lattice below - an inherited bare 'latest' would race the Debian
+            # image for that tag (plan 003 section 6).
+            entry_tags = matrix_entry.get('additional_tags', additional_tags)
             if os_name == 'alpine':
                 alpine_role = matrix_entry.get('alpine_role') or (
                     'edge' if distribution == 'edge' else 'stable')

--- a/tests/test_build_matrix_alpine_tags.py
+++ b/tests/test_build_matrix_alpine_tags.py
@@ -6,7 +6,9 @@ Debian/semantic version-level tags (latest, stable, 22, bare 22.10.1) and, on
 --push, collided with the Debian image for those tags. The CI matrix generator
 (.github/actions/generate-build-matrix) already REPLACES an Alpine member's
 tags with lib/alpine_tags.py's lattice; this pins that the LOCAL path does the
-same, while Debian members keep their version-level tags byte-for-byte.
+same. Debian members honor per-member additional_tags overrides (forky's
+'experimental'), while members without the key (trixie) keep the version-level
+tags - matching the CI generator's line-128 behavior.
 
 Style mirrors tests/test_golden_regeneration.py: build-asterisk.sh --dry-run
 runs inside a throwaway git worktree so generated files are never written into
@@ -99,20 +101,24 @@ class TestAlpineLegEmitsLattice:
         assert "22-alpine" not in alpine_edge
 
 
-class TestDebianLegKeepsVersionTags:
-    """Debian legs are untouched by the Alpine fix (tags stay byte-identical)."""
+class TestDebianLegTags:
+    """Debian legs: members without a per-member tag keep the version-level
+    tags (trixie); members with one honor it (forky's 'experimental'), matching
+    the CI generator's line-128 behavior."""
 
     def test_trixie_keeps_version_level_tags(self, worktree):
         assert _tags_by_leg(worktree, "22.10.1")[("debian", "trixie")] == [
             "latest", "stable", "22",
         ]
 
-    def test_forky_leg_unchanged_and_alpine_still_lattice(self, worktree):
-        # Guards the design trap: the local path must NOT adopt per-member tags,
-        # so 23.4.1's forky leg stays '23' (its member-level 'experimental' tag
-        # is a pre-existing, separate concern - out of scope for this fix).
+    def test_forky_adopts_its_experimental_tag(self, worktree):
+        # The local path honors per-member additional_tags (parity with the CI
+        # generator): 23.4.1's forky leg publishes its own 'experimental' tag
+        # instead of inheriting the version-level '23', which would collide with
+        # the trixie '23' image. trixie has no per-member key, so it keeps the
+        # version-level '23'.
         legs = _tags_by_leg(worktree, "23.4.1")
         assert legs[("debian", "trixie")] == ["23"]
-        assert legs[("debian", "forky")] == ["23"]
+        assert legs[("debian", "forky")] == ["experimental"]
         # ...while the Alpine legs of the same version carry the lattice.
         assert "23.4.1-alpine-3.24" in legs[("alpine", "3.24")]


### PR DESCRIPTION
## Honor per-member `additional_tags` on the local build path

`get_build_matrix()` in `scripts/build-asterisk.sh` applied the **version-level**
`additional_tags` to every Debian `os_matrix` member, ignoring per-member
overrides. So a manual `./scripts/build-asterisk.sh 23.4.1 --push` tagged the
`forky` leg `23` - **colliding with the `trixie` `23` image**. The CI matrix
generator (`.github/actions/generate-build-matrix/action.yml:128`) was already
correct; this brings the local path to parity.

This is the same class of bug fixed for Alpine in #172, which deliberately
scoped itself "Debian byte-identical" and left this Debian half for a separate
PR (this one).

### Fix

One line in `get_build_matrix()`, mirroring the CI action:

```python
entry_tags = matrix_entry.get('additional_tags', additional_tags)  # was: entry_tags = additional_tags
```

Members without a per-member tag (trixie, alpine) fall back to the version-level
value exactly as before; `forky`'s `experimental` is now honored. The Alpine
branch immediately below still **replaces** `entry_tags` with the tag lattice, so
Alpine legs are unaffected. The inverted #172 comment was rewritten.

### Blast radius (observable, local path)

Exactly **one active member** changes: `23.4.1/forky` `23` -> `experimental`
(fixes the trixie collision). Everything else is unchanged:

- **`23.3.0/forky` is moot** - 23.3.0 is `deprecated` (`superseded_by: 23.4.1`),
  and `get_build_matrix` early-exits on deprecated versions before the per-member
  loop (CI skips deprecated Debian members too, so no local/CI divergence). Its
  change is latent, only manifesting if 23.3.0 were un-deprecated.
- **`git` unaffected** - local git builds use the separate `GIT_BUILD` branch,
  bypassing `get_build_matrix`.
- **No non-forky Debian member** carries a per-member `additional_tags`.

### Tests

`tests/test_build_matrix_alpine_tags.py`: `test_forky_adopts_its_experimental_tag`
(renamed from `..._unchanged...`) now asserts `forky == ["experimental"]` and
`trixie == ["23"]`; the class and module docstring were reconciled (they
previously claimed Debian legs universally keep version-level tags). Full suite
**112 passed**; golden regeneration green (tags do not affect generated files).

### Verification

- `python3 -m pytest tests/` -> **112 passed**.
- `./scripts/build-asterisk.sh 23.4.1 --dry-run`: `forky [additional_tags: experimental]`, `trixie [additional_tags: 23]`, alpine legs carry the lattice.
- `./scripts/build-asterisk.sh 22.10.1 --dry-run`: unchanged (no forky member).
- No files under `asterisk/` or `configs/generated/` change.
