### PR TITLE
test(lifecycle): drill the deprecation timeline loop via 23.3.0 re-stamp

### DIFF
--- a/asterisk/supported-asterisk-builds.yml
+++ b/asterisk/supported-asterisk-builds.yml
@@ -447,7 +447,6 @@ latest_builds:
         additional_tags: "experimental"
 
     superseded_by: "23.4.1"
-    deprecated_at: "2026-07-04T16:43:46Z"
   - version: "20.20.1"
     os_matrix:
       - os: "debian"


### PR DESCRIPTION
Controlled end-to-end drill of the deprecation → timeline → deploy chain (#170). Drops `deprecated_at` from the already-superseded 23.3.0; on merge, `finalize-deprecations` re-stamps it and dispatches the timeline entry. A follow-up PR restores the original `2026-07-04T16:43:46Z` timestamp, and the drill entry is removed from the blog timeline afterwards.