### PR TITLE
test(lifecycle): restore original 23.3.0 deprecation timestamp after drill

### DIFF
--- a/asterisk/supported-asterisk-builds.yml
+++ b/asterisk/supported-asterisk-builds.yml
@@ -447,7 +447,7 @@ latest_builds:
         additional_tags: "experimental"
 
     superseded_by: "23.4.1"
-    deprecated_at: "2026-07-18T04:33:18Z"
+    deprecated_at: "2026-07-04T16:43:46Z"
   - version: "20.20.1"
     os_matrix:
       - os: "debian"


### PR DESCRIPTION
Closes the drill from #174 - restores `deprecated_at: 2026-07-04T16:43:46Z` on 23.3.0. On merge, `finalize-deprecations` finds nothing pending (no dispatch) and its README regeneration self-heals the version table.