### PR TITLE
ci: use client-id instead of deprecated app-id for the App token

### DIFF
--- a/.github/workflows/alpine-sync.yml
+++ b/.github/workflows/alpine-sync.yml
@@ -46,7 +46,10 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          # RELEASE_BOT_APP_ID holds the numeric App ID; create-github-app-token
+          # accepts it as the client-id (GitHub still honors the App ID as the
+          # JWT issuer). Using client-id silences the deprecated app-id input.
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/discover-releases.yml
+++ b/.github/workflows/discover-releases.yml
@@ -32,7 +32,10 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          # RELEASE_BOT_APP_ID holds the numeric App ID; create-github-app-token
+          # accepts it as the client-id (GitHub still honors the App ID as the
+          # JWT issuer). Using client-id silences the deprecated app-id input.
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Silence the `app-id` -> `client-id` deprecation

`actions/create-github-app-token@v3` deprecated the `app-id` input in favor of
`client-id` (the live warning: `Input 'app-id' has been deprecated ... Use 'client-id' instead`).
Surfaced during the alpine-sync live test. Applied to both workflows that mint an
App token: `alpine-sync.yml` and `discover-releases.yml`.

### Why this is safe (no new secret)

`RELEASE_BOT_APP_ID` holds the **numeric App ID**. The action accepts it as
`client-id`, and GitHub still honors the App ID as the JWT issuer (`iss`), so the
generated JWT is byte-for-byte what it was before - **a no-op at runtime**, just
using the non-deprecated input name. Verified against the real `action.yml` at
the `v3` ref: `client-id` is a defined input; `app-id` carries the deprecation.

The "proper" alternative (a dedicated `RELEASE_BOT_CLIENT_ID` variable with the
App's Client ID string) was considered and declined - it needs a new config value
for zero functional gain here.

### Note for reviewers

`actionlint` flags `client-id` as undefined / `app-id` as required for this action
- that is **stale bundled metadata** (predates the `client-id` input). The
authoritative `action.yml@v3` defines `client-id`. `actionlint` is not a CI gate
in this repo.