### PR TITLE
fix(ci): generate entrypoint.sh for pre-v10 Alpine members

### DIFF
--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -408,23 +408,27 @@ jobs:
           chmod +x healthcheck.sh
           echo "✅ Generated healthcheck script"
 
-      - name: Generate entrypoint script (v10+ only)
+      - name: Generate entrypoint script (v10+, and always for Alpine)
         working-directory: .
         run: |
           VERSION="${{ inputs.version }}"
+          OS_TYPE="${{ steps.validate-config.outputs.os_type }}"
           if [[ "$VERSION" =~ ^git ]]; then
             MAJOR=99
           else
             MAJOR="${VERSION%%.*}"
           fi
 
-          if [ "$MAJOR" -ge 10 ]; then
+          # Mirror scripts/build-asterisk.sh: the Alpine apk Dockerfile
+          # unconditionally COPYs entrypoint.sh, so generate it for every
+          # Alpine member regardless of Asterisk major version.
+          if [ "$MAJOR" -ge 10 ] || [ "$OS_TYPE" = "alpine" ]; then
             sed "s/{{ config\.version }}/${VERSION}/g" \
               templates/partials/entrypoint.sh.j2 > entrypoint.sh
             chmod +x entrypoint.sh
-            echo "✅ Generated entrypoint script for v${MAJOR}"
+            echo "✅ Generated entrypoint script for v${MAJOR} (os=${OS_TYPE})"
           else
-            echo "⏭️  Skipped entrypoint script (v${MAJOR} pre-v10)"
+            echo "⏭️  Skipped entrypoint script (v${MAJOR} pre-v10, os=${OS_TYPE})"
             # Create empty placeholder so artifact upload pattern doesn't fail
             : > entrypoint.sh.skipped
           fi


### PR DESCRIPTION
## Problem

The scheduled `Build Batch - Monday (Legacy 1.x-10.x)` run failed on both Alpine members:

- `1.6.2.24-alpine-3.24` - `"/entrypoint.sh": not found`
- `1.8.32.3-alpine-3.24` - `"/entrypoint.sh": not found`

All Debian legs succeeded. (Run: 29729830342)

## Root cause

The Alpine apk Dockerfile (`templates/dockerfile/alpine-apk.dockerfile.j2`) unconditionally `COPY entrypoint.sh`, but the **CI** "Generate entrypoint script" step in `build-single-image.yml` gated generation on `MAJOR >= 10` only. For these two pre-v10 Alpine members the step skipped `entrypoint.sh`, the uploaded artifact carried no `entrypoint.sh` (`if-no-files-found: warn` let it pass silently), and buildx failed on the `COPY`.

60b3f1a fixed this on the **local** path (`scripts/build-asterisk.sh`), but the CI regeneration step was never updated to match - so the committed tree (enforced by `validate-generation.yml`, which requires `entrypoint.sh` for every Alpine member) diverged from what CI regenerates.

## Fix

Mirror the local condition in the CI step: also generate `entrypoint.sh` when `os_type == alpine`, regardless of major version. Reuses the existing `steps.validate-config.outputs.os_type` (already emitted at line 159 and consumed elsewhere in the job).

Blast radius: exactly these 2 members. `git` (major=99) and all major>=20 Alpine members were already covered by the `>= 10` gate.

## Verification

- YAML parses cleanly; no syntax errors.
- `pytest tests/` - 112 passed (no regression; change is YAML-only, no Python touched).
- Targeted re-run of the two legs via `workflow_dispatch` on `build-single-image.yml` confirms the build after merge (cannot run buildx from here).