### PR TITLE
fix(alpine): resolve newest apk revision; bump 1.6.2.24 to -r1

### DIFF
--- a/asterisk/1.6.2.24-alpine-3.24/Dockerfile
+++ b/asterisk/1.6.2.24-alpine-3.24/Dockerfile
@@ -22,11 +22,10 @@ COPY cloudsmith-asterisk-alpine.rsa.pub /etc/apk/keys/alpine@asterisk-25B0C9A992
 # reproducible (or fail loudly if the apk was pruned).
 RUN echo "@andrius-asterisk https://dl.cloudsmith.io/public/asterisk/alpine/alpine/v3.24/main" >>/etc/apk/repositories \
     && apk add --no-cache \
-        "asterisk@andrius-asterisk=1.6.2.24-r0" \
-        "asterisk-sample-config@andrius-asterisk=1.6.2.24-r0" \
-        "asterisk-fax@andrius-asterisk=1.6.2.24-r0" \
-        "asterisk-odbc@andrius-asterisk=1.6.2.24-r0" \
-        "asterisk-tds@andrius-asterisk=1.6.2.24-r0" \
+        "asterisk@andrius-asterisk=1.6.2.24-r1" \
+        "asterisk-sample-config@andrius-asterisk=1.6.2.24-r1" \
+        "asterisk-fax@andrius-asterisk=1.6.2.24-r1" \
+        "asterisk-odbc@andrius-asterisk=1.6.2.24-r1" \
         bash \
         shadow \
         gettext \

--- a/asterisk/supported-asterisk-builds.yml
+++ b/asterisk/supported-asterisk-builds.yml
@@ -63,8 +63,8 @@ latest_builds:
         distribution: "3.24"
         alpine_tree: "v3.24"
         alpine_role: "stable"
-        apk_version: "1.6.2.24-r0"
-        apk_packages: ["fax", "odbc", "tds"]
+        apk_version: "1.6.2.24-r1"
+        apk_packages: ["fax", "odbc"]
         architectures:
           - "amd64"
     tarball_sha256: "5f5b28f7644eeef6ecf778b4cdbbfe89ef70d482943af9b2e588823bd8ef0e54"

--- a/configs/generated/asterisk-1.6.2.24-alpine-3.24.yml
+++ b/configs/generated/asterisk-1.6.2.24-alpine-3.24.yml
@@ -43,5 +43,4 @@ alpine:
   apk_packages:
   - fax
   - odbc
-  - tds
-  apk_version: 1.6.2.24-r0
+  apk_version: 1.6.2.24-r1

--- a/lib/alpine_sync.py
+++ b/lib/alpine_sync.py
@@ -131,6 +131,19 @@ def _pkgver_sort_key(pkgver: str) -> Tuple:
     return tuple(int(n) for n in nums)
 
 
+def _pkgver_full_sort_key(pkgver: str) -> Tuple:
+    """Sort key over numeric components INCLUDING the ``-rN`` pkgrel revision.
+
+    Unlike :func:`_pkgver_sort_key` (which strips ``-rN``), this distinguishes
+    ``1.6.2.24-r0`` from ``1.6.2.24-r1`` so a revision bump resolves to the
+    newest rebuild rather than a stale earlier pkgrel.
+    """
+    m = _RN_RE.search(pkgver)
+    rev = int(m.group(0)[2:]) if m else 0
+    base = _strip_rn(pkgver)
+    return tuple(int(n) for n in re.findall(r"\d+", base)) + (rev,)
+
+
 def resolve_pkgver(label: str, pkgvers) -> Optional[str]:
     """Map our matrix label to the exact published pkgver present in ``pkgvers``.
 
@@ -147,10 +160,16 @@ def resolve_pkgver(label: str, pkgvers) -> Optional[str]:
 
     cert = _CERT_RE.match(label)
     target = f"{cert.group(1)}.{cert.group(2)}.0.{cert.group(3)}" if cert else label
-    for v in pkgvers:
-        if _strip_rn(v) == target:
-            return v
-    return None
+    matches = [v for v in pkgvers if _strip_rn(v) == target]
+    if not matches:
+        return None
+    # Pick the highest pkgrel revision (-rN). The sibling re-publishes bug-fix
+    # rebuilds as -r1, -r2, ... and a stale -r0 can ship a subpackage set the
+    # newer revision dropped (e.g. asterisk-tds on legacy 1.6.2.24). Selecting
+    # by max() is also deterministic; the old first-match walked a set whose
+    # order varied across processes (PYTHONHASHSEED), so the same index could
+    # resolve to -r0 or -r1 depending on the run.
+    return max(matches, key=_pkgver_full_sort_key)
 
 
 def derive_roles(live_trees) -> Dict[str, str]:

--- a/tests/test_alpine_sync.py
+++ b/tests/test_alpine_sync.py
@@ -118,6 +118,17 @@ class TestResolvePkgver:
     def test_missing_returns_none(self):
         assert A.resolve_pkgver("99.9.9", {"22.10.1-r0"}) is None
 
+    def test_picks_highest_revision_when_multiple_pkgrels(self):
+        # Sibling re-publishes rebuilds as -r1, -r2, ...; the resolver must
+        # take the newest revision deterministically, not whatever a set
+        # iteration happened to yield (PYTHONHASHSEED made it random).
+        pkgvers = {"1.6.2.24-r0", "1.6.2.24-r1"}
+        assert A.resolve_pkgver("1.6.2.24", pkgvers) == "1.6.2.24-r1"
+
+    def test_picks_highest_revision_across_three_pkgrels(self):
+        pkgvers = {"20.20.1-r2", "20.20.1-r0", "20.20.1-r1"}
+        assert A.resolve_pkgver("20.20.1", pkgvers) == "20.20.1-r2"
+
 
 class TestDeriveRoles:
     def test_single_stable_and_edge(self):


### PR DESCRIPTION
## Problem

The scheduled `Build Batch - Monday (Legacy 1.x-10.x)` failed for
`1.6.2.24-alpine-3.24` at the `apk add` step with:

```
ERROR: unable to select packages:
  asterisk-tds-24.0.0_git20260722-r0:
    breaks: world[asterisk-tds=1.6.2.24-r0@andrius-asterisk]
```

## Root cause

Two compounding issues, both fixed here:

1. **Non-deterministic revision selection.** `lib/alpine_sync.resolve_pkgver()`
   walked a `set` and returned the *first* pkgver whose stripped form matched
   the label. Set iteration order varies across processes (PYTHONHASHSEED), so
   when the sibling publishes both `-r0` and `-r1` rebuilds, the daily sync
   could land on either. It landed on `1.6.2.24-r0`.

2. **apk3 solver bug + stale revision.** The sibling's `-r1` rebuild of
   1.6.2.24 deliberately omits `asterisk-tds`. The stale `-r0` still carries
   it, and selecting `asterisk-tds=1.6.2.24-r0` triggers an apk3 (Alpine 3.24)
   solver bug: it cannot pick that version while a higher `24.0.0_git` exists,
   ignoring the `@tag`/`=version` pin. (Reproduced in isolation; `apk version`
   comparison is correct, the bug is in version *selection*.)

> Note: the prior theory ("ours < official 22.9.0") was a red herring. apk's
> version comparison is correct, and only `asterisk-tds` + the `1.6.2.24-r0`
> combination is affected.

## Fix

- `lib/alpine_sync.py`: add `_pkgver_full_sort_key` (includes the `-rN`
  pkgrel, unlike `_pkgver_sort_key` which strips it) and make
  `resolve_pkgver()` pick the **highest revision deterministically**. This
  stops the r0/r1 coin-flip and is forward-correct: any future line the
  sibling re-publishes as `-rN` will resolve to the newest rebuild.
- `asterisk/supported-asterisk-builds.yml`: the `1.6.2.24` Alpine member is
  bumped to `1.6.2.24-r1` and `tds` is dropped from `apk_packages` (the `-r1`
  rebuild does not publish it). This is exactly what the corrected resolver
  produces; the matrix is synced rather than hand-invented.
- Regenerated `configs/generated/asterisk-1.6.2.24-alpine-3.24.yml` and
  `asterisk/1.6.2.24-alpine-3.24/Dockerfile` to match.

Scope is surgical: only the 1.6.2.24 Alpine member changes. `1.8.32.3` is
unaffected (still `-r0`, installs cleanly). Modern lines (20/22/23) each have
only `-r0` published, so the resolver fix is a no-op for them today.

## Verification

- `python3 -m pytest tests/` -> 114 passed (112 prior + 2 new revision-selection tests).
- Local image build of `1.6.2.24-alpine-3.24` succeeds end-to-end (the
  previously-failing `apk add` step now passes); `asterisk -V` reports
  `Asterisk 1.6.2.24`, 104 modules loaded, no tds module (expected).
- `alpine-sync --dry-run` resolves `1.6.2.24 -> 3.24=1.6.2.24-r1`.

## Follow-ups (not in this PR)

- PR #177 (the separate `entrypoint.sh` generation bug) is still open with no
  CI checks and will be handled separately.
- The daily `alpine-sync` would also surface alpine members for the
  deprecated 14.7.8 / 16.30.1 / 18.26.4 lines now that the sibling publishes
  their apks; that matrix expansion is left to a normal sync run, not bundled
  into this fix.
