### PR TITLE
fix(ci): unique per-arch digest artifact names for 4-arch alpine builds

### DIFF
--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -227,7 +227,8 @@ jobs:
                   runner = RUNNER.get(arch, 'ubuntu-latest')  # 32-bit ARM -> QEMU on amd64
                   matrix_include.append({
                       'platform': platform,
-                      'runner': runner
+                      'runner': runner,
+                      'arch': arch
                   })
 
           platforms_matrix = {'include': matrix_include}
@@ -607,7 +608,7 @@ jobs:
         if: steps.build-config.outputs.use_tags == 'false'
         uses: actions/upload-artifact@v7
         with:
-          name: digests-${{ inputs.version }}-${{ inputs.distribution }}-${{ contains(matrix.platform, 'amd64') && 'amd64' || 'arm64' }}
+          name: digests-${{ inputs.version }}-${{ inputs.distribution }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
## Problem

The Thursday certified batch failed (run [29993016027](https://github.com/andrius/asterisk/actions/runs/29993016027)) on the `22.8-cert3` Alpine build at the **merge** step:

```
Expected digests: 4
Actual digests: 2
❌ ERROR: Digest count mismatch!
```

All four platform builds (`amd64`, `arm64`, `arm/v7`, `arm/v6`) **succeeded** - only the merge failed.

## Root cause

`build-single-image.yml` named each per-platform digest artifact with a binary guess:

```yaml
name: digests-...-${{ contains(matrix.platform, 'amd64') && 'amd64' || 'arm64' }}
```

For `linux/arm/v7` and `linux/arm/v6`, `contains(..., 'amd64')` is false, so **both got mislabeled `arm64`** and collided with the real arm64 artifact. GitHub collapses same-named artifacts across matrix jobs, leaving only `amd64` + `arm64` - hence 2 digests instead of 4.

## Fix

`prepare-matrix` already knows the arch token; expose it on the matrix and use it:

```python
matrix_include.append({'platform': platform, 'runner': runner, 'arch': arch})
```
```yaml
name: digests-${{ inputs.version }}-${{ inputs.distribution }}-${{ matrix.arch }}
```

Each platform now gets a unique name (`digests-<v>-<dist>-{amd64,arm64,armv7,armhf}`); the merge job's existing `digests-...-*` wildcard collects all four.

## Scope

Every 4-arch Alpine member is affected: `22.8-cert3`, `22.10.1`, `23.4.1` (all on 3.24). amd64-only and 2-arch builds are unaffected (no collision possible). Line 473's `contains(matrix.platform, 'arm/v')` (the QEMU gate) is correct and untouched.

## Verification

A `workflow_dispatch` of this workflow on this branch with
`version=22.8-cert3 distribution=3.24 architectures=amd64,arm64,armv7,armhf push=true`
is attached as the verification - the merge step must report 4/4 digests and create the multi-arch manifest (previously 2/4). Result will be noted here.
