### PR TITLE
fix(alpine): skip arches whose pinned apk isn't published yet

### DIFF
--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -548,6 +548,42 @@ jobs:
           cp templates/partials/keys/cloudsmith-asterisk-alpine.rsa.pub ./
           echo "✅ Staged Cloudsmith signing key into the build context"
 
+      - name: Verify pinned apks are published for this arch
+        id: apk-gate
+        if: needs.validate-and-prepare.outputs.os_type == 'alpine'
+        run: |
+          # Defense against the sibling's partial-publish window
+          # (andrius/asterisk-alpine#39): the exact apk_version pin is
+          # unsatisfiable on an arch if the main apk is live there but a
+          # subpackage at the same pkgver is not yet. Skip THIS arch instead of
+          # failing the whole multi-arch manifest; the daily alpine-sync
+          # re-pins once the sibling settles and the next run rebuilds it.
+          CONFIG="configs/generated/asterisk-${{ inputs.version }}-alpine-${{ inputs.distribution }}.yml"
+          set +e
+          python3 scripts/check-alpine-apk-availability.py \
+            --config "$CONFIG" --arch "${{ matrix.arch }}"
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "skip=false" >> "$GITHUB_OUTPUT" ;;
+            2)
+              if [ "${{ needs.validate-and-prepare.outputs.is_multi_platform }}" != "true" ]; then
+                # Single-platform: skipping would ship no image at all, so fail
+                # loudly instead and let the next alpine-sync re-pin.
+                echo "::error::Pinned apk not published for the only arch ${{ matrix.arch }}; see andrius/asterisk-alpine#39"
+                exit 1
+              fi
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              printf 'arch=%s platform=%s reason=pinned-apk-not-published\n' \
+                "${{ matrix.arch }}" "${{ matrix.platform }}" > /tmp/skipped.txt
+              echo "::warning::Skipping ${{ matrix.platform }}: a pinned apk is not yet published for ${{ matrix.arch }} (sibling partial-publish window); see andrius/asterisk-alpine#39"
+              ;;
+            *)
+              echo "::error::Availability gate hard-failed (rc=$rc) for ${{ matrix.arch }}"
+              exit 1
+              ;;
+          esac
+
       - name: Prepare build configuration
         id: build-config
         run: |
@@ -577,6 +613,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
+        if: steps.apk-gate.outputs.skip != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -597,7 +634,7 @@ jobs:
             BUILDKIT_INLINE_CACHE=1
 
       - name: Export digest
-        if: steps.build-config.outputs.use_tags == 'false'
+        if: steps.build-config.outputs.use_tags == 'false' && steps.apk-gate.outputs.skip != 'true'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
@@ -605,11 +642,22 @@ jobs:
           echo "Exported digest: $digest"
 
       - name: Upload digest
-        if: steps.build-config.outputs.use_tags == 'false'
+        if: steps.build-config.outputs.use_tags == 'false' && steps.apk-gate.outputs.skip != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ inputs.version }}-${{ inputs.distribution }}-${{ matrix.arch }}
           path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Record skipped arch (no pinned apk published)
+        # When the gate skipped this arch, upload a marker so the merge job can
+        # lower its expected digest count instead of failing the manifest.
+        if: steps.build-config.outputs.use_tags == 'false' && steps.apk-gate.outputs.skip == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: skip-${{ inputs.version }}-${{ inputs.distribution }}-${{ matrix.arch }}
+          path: /tmp/skipped.txt
           if-no-files-found: error
           retention-days: 1
 
@@ -688,6 +736,17 @@ jobs:
           pattern: digests-${{ inputs.version }}-${{ inputs.distribution }}-*
           merge-multiple: true
 
+      - name: Download skip markers
+        # Best-effort: present only when an arch leg was skipped by the apk
+        # availability gate. Empty when every arch built. continue-on-error so
+        # a transient artifact-service hiccup cannot block the manifest.
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/skipped
+          pattern: skip-${{ inputs.version }}-${{ inputs.distribution }}-*
+          merge-multiple: true
+
       - name: Prepare digest list
         id: digest-list
         run: |
@@ -725,23 +784,31 @@ jobs:
 
       - name: Validate digest count
         run: |
-          EXPECTED_COUNT="${{ needs.validate-and-prepare.outputs.platform_count }}"
+          PLATFORM_COUNT="${{ needs.validate-and-prepare.outputs.platform_count }}"
+          SKIPPED_COUNT=$(find /tmp/skipped -type f 2>/dev/null | wc -l | tr -d ' ')
           DIGEST_LIST="${{ steps.digest-list.outputs.digest_images }}"
-          ACTUAL_COUNT=$(echo "$DIGEST_LIST" | wc -w)
+          ACTUAL_COUNT=$(echo "$DIGEST_LIST" | wc -w | tr -d ' ')
 
+          EXPECTED_COUNT=$((PLATFORM_COUNT - SKIPPED_COUNT))
+
+          echo "Platform legs: $PLATFORM_COUNT"
+          echo "Skipped legs:  $SKIPPED_COUNT (apk availability gate)"
           echo "Expected digests: $EXPECTED_COUNT"
-          echo "Actual digests: $ACTUAL_COUNT"
+          echo "Actual digests:   $ACTUAL_COUNT"
 
-          if [[ "$ACTUAL_COUNT" != "$EXPECTED_COUNT" ]]; then
-            echo "❌ ERROR: Digest count mismatch!"
-            echo "Expected $EXPECTED_COUNT platform(s), but found $ACTUAL_COUNT digest(s)"
-            echo ""
-            echo "This indicates one or more platform builds failed to upload digests."
+          if [ "$EXPECTED_COUNT" -le 0 ]; then
+            echo "::error::Every platform leg was skipped - no pinned apk published for any arch. See andrius/asterisk-alpine#39."
+            exit 1
+          fi
+
+          if [ "$ACTUAL_COUNT" != "$EXPECTED_COUNT" ]; then
+            echo "::error::Digest count mismatch: expected $EXPECTED_COUNT ($PLATFORM_COUNT platforms minus $SKIPPED skipped), found $ACTUAL_COUNT."
+            echo "This means a platform build neither produced a digest nor registered as skipped."
             echo "Check the build job logs for failures."
             exit 1
           fi
 
-          echo "✅ All expected digests present"
+          echo "✅ All expected digests present ($ACTUAL_COUNT built, $SKIPPED skipped)"
 
       - name: Create multi-platform manifests
         run: |

--- a/lib/alpine_sync.py
+++ b/lib/alpine_sync.py
@@ -48,6 +48,10 @@ ARCH_MAP = {
     "armv7": "armv7",
     "armhf": "armhf",
 }
+# Inverse of ARCH_MAP: our matrix arch name -> Cloudsmith arch segment. Used by
+# the pre-build availability gate (scripts/check-alpine-apk-availability.py) to
+# pick which per-arch APKINDEX to fetch for a matrix leg.
+MATRIX_TO_CLOUD = {v: k for k, v in ARCH_MAP.items()}
 ARCH_ORDER = ["amd64", "arm64", "armv7", "armhf"]
 
 # The arch segments we probe on every tree (32-bit indexes may be empty).
@@ -112,6 +116,34 @@ def parse_apkindex(tar_gz_bytes: bytes) -> List[Dict[str, str]]:
             "arch": cur.get("arch", ""),
         })
     return records
+
+
+def install_names(apk_packages):
+    """The exact apk install list the Alpine Dockerfile pins to ``apk_version``.
+
+    ``asterisk`` (main) and ``asterisk-sample-config`` are always installed;
+    each short subpackage name (e.g. ``"tds"``) becomes ``asterisk-tds``. This
+    mirrors templates/dockerfile/alpine-apk.dockerfile.j2 and is shared with the
+    pre-build availability gate so the two can never drift.
+    """
+    return ["asterisk", "asterisk-sample-config"] + [
+        f"asterisk-{p}" for p in (apk_packages or [])
+    ]
+
+
+def missing_pinned_packages(records, apk_version, names):
+    """Return the subset of ``names`` whose exact ``apk_version`` is absent.
+
+    A package is "present for this arch" iff some record in ``records`` (the
+    parsed APKINDEX for ONE arch) has ``version == apk_version``. Used by the
+    pre-build availability gate to decide whether a matrix arch can be built
+    now or must be skipped until the sibling finishes publishing that pkgver's
+    full arch+subpackage set (see andrius/asterisk-alpine#39).
+
+    Pure: no I/O. ``records`` comes from :func:`parse_apkindex`.
+    """
+    present = {r["name"] for r in records if r["version"] == apk_version}
+    return [n for n in names if n not in present]
 
 
 def tree_to_distribution(tree: str) -> str:

--- a/scripts/check-alpine-apk-availability.py
+++ b/scripts/check-alpine-apk-availability.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Pre-build availability gate for Alpine apk images.
+
+Reads the generated Alpine config for a (version, distribution), resolves the
+Cloudsmith arch segment for our matrix arch name, fetches that arch's
+APKINDEX.tar.gz, and checks that ``asterisk``, ``asterisk-sample-config`` and
+every selected ``asterisk-<sub>`` subpackage is present at exactly
+``apk_version``.
+
+Why: the sibling repo (andrius/asterisk-alpine) publishes the main package and
+its subpackages in one batch; under transient failure the main can be live on an
+arch before every subpackage at the same pkgver is (andrius/asterisk-alpine#39).
+The consumer pins the exact version (subpackages carry no ``depend: asterisk``),
+so a partial set is unsatisfiable. Rather than fail a multi-arch manifest for
+that, the calling workflow skips THIS arch and retries it next sync.
+
+Exit codes (consumed by .github/workflows/build-single-image.yml):
+  0 - every pinned package is published for this arch; proceed to build.
+  2 - some pinned package is missing; skip this arch gracefully.
+  1 - hard error (bad config, unknown arch, network/parse failure); fail the leg.
+
+Pure availability logic lives in lib/alpine_sync.py (install_names +
+missing_pinned_packages); this script is the I/O wrapper, mirroring the fetch()
+style of scripts/alpine-sync.py.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+import yaml
+
+sys.path.insert(0, "lib")
+import alpine_sync as A  # noqa: E402
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--config", required=True,
+                   help="generated alpine config yml (configs/generated/asterisk-<v>-alpine-<dist>.yml)")
+    p.add_argument("--arch", required=True,
+                   help="our matrix arch name (amd64/arm64/armv7/armhf)")
+    args = p.parse_args(argv)
+
+    cloud_arch = A.MATRIX_TO_CLOUD.get(args.arch)
+    if cloud_arch is None:
+        print(f"hard error: unknown matrix arch {args.arch!r}", file=sys.stderr)
+        return 1
+
+    try:
+        with open(args.config) as f:
+            cfg = yaml.safe_load(f)
+        alpine = cfg["alpine"]
+        apk_version = alpine["apk_version"]
+        repo_url = alpine["repo_url"].rstrip("/")
+        names = A.install_names(alpine.get("apk_packages", []))
+    except (OSError, KeyError, TypeError, yaml.YAMLError) as e:
+        print(f"hard error reading config {args.config}: {e}", file=sys.stderr)
+        return 1
+
+    url = f"{repo_url}/{cloud_arch}/APKINDEX.tar.gz"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            records = A.parse_apkindex(resp.read())
+    except urllib.error.HTTPError as e:
+        print(f"hard error: index not reachable for {args.arch}: "
+              f"HTTP {e.code} {url}", file=sys.stderr)
+        return 1
+    except (urllib.error.URLError, OSError) as e:
+        print(f"hard error fetching {url}: {e}", file=sys.stderr)
+        return 1
+
+    missing = A.missing_pinned_packages(records, apk_version, names)
+    if not missing:
+        print(f"ok: all {len(names)} pinned packages present at {apk_version} "
+              f"for {args.arch}")
+        return 0
+
+    # exit 2 = "skip this arch", not a hard failure. Emit JSON the workflow can
+    # surface in the build summary.
+    print(json.dumps({
+        "arch": args.arch, "apk_version": apk_version, "missing": missing}))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_alpine_sync.py
+++ b/tests/test_alpine_sync.py
@@ -260,3 +260,64 @@ class TestArchMapping:
         assert A.ARCH_MAP == {
             "x86_64": "amd64", "aarch64": "arm64",
             "armv7": "armv7", "armhf": "armhf"}
+
+    def test_matrix_to_cloud_is_exact_inverse(self):
+        # the pre-build gate uses MATRIX_TO_CLOUD to pick the APKINDEX arch
+        assert A.MATRIX_TO_CLOUD == {
+            "amd64": "x86_64", "arm64": "aarch64",
+            "armv7": "armv7", "armhf": "armhf"}
+        for cloud, matrix in A.ARCH_MAP.items():
+            assert A.MATRIX_TO_CLOUD[matrix] == cloud
+
+
+class TestInstallNames:
+    def test_main_plus_sample_config_plus_subs(self):
+        assert A.install_names(["opus", "tds"]) == [
+            "asterisk", "asterisk-sample-config",
+            "asterisk-opus", "asterisk-tds"]
+
+    def test_empty_subpackages_still_installs_main(self):
+        assert A.install_names([]) == ["asterisk", "asterisk-sample-config"]
+
+    def test_none_subpackages(self):
+        # config may omit apk_packages; the gate must not crash on None
+        assert A.install_names(None) == ["asterisk", "asterisk-sample-config"]
+
+
+class TestMissingPinnedPackages:
+    """The pre-build availability gate's pure core: which pinned names are
+    absent from one arch's parsed APKINDEX at the exact apk_version."""
+
+    def _records(self, present_names, apk_version):
+        return [{"name": n, "version": apk_version, "arch": "x86_64"}
+                for n in present_names]
+
+    def test_all_present_returns_empty(self):
+        recs = self._records(
+            ["asterisk", "asterisk-sample-config", "asterisk-tds"], "22.10.1-r0")
+        assert A.missing_pinned_packages(
+            recs, "22.10.1-r0", A.install_names(["tds"])) == []
+
+    def test_missing_subpackage_reported(self):
+        # the armv7/armhf race: main is live, asterisk-tds is not (only an
+        # older pkgver, which must NOT count as present).
+        recs = self._records(["asterisk", "asterisk-sample-config"], "22.10.1-r0") \
+            + [{"name": "asterisk-tds", "version": "22.9.0-r0", "arch": "armv7"}]
+        assert A.missing_pinned_packages(
+            recs, "22.10.1-r0", A.install_names(["tds"])) == ["asterisk-tds"]
+
+    def test_wrong_version_does_not_count_as_present(self):
+        recs = [{"name": "asterisk", "version": "22.9.0-r0", "arch": "arm64"}]
+        assert A.missing_pinned_packages(recs, "22.10.1-r0", ["asterisk"]) \
+            == ["asterisk"]
+
+    def test_preserves_requested_order(self):
+        recs = []  # nothing published for this arch
+        names = A.install_names(["opus", "tds", "pgsql"])
+        assert A.missing_pinned_packages(recs, "22.10.1-r0", names) == names
+
+    def test_uses_real_fixture_index(self):
+        # the captured x86_64 fixture ships asterisk + asterisk-tds at 22.10.1
+        recs = _load("v3.24-x86_64")
+        assert A.missing_pinned_packages(
+            recs, "22.10.1-r0", A.install_names(["tds"])) == []


### PR DESCRIPTION
## Problem

Alpine matrix legs fail when the pinned `apk_version` is unsatisfiable on an arch: the main `asterisk` apk is live there but a subpackage (e.g. `asterisk-tds`) at the same pkgver is not yet published - the sibling repo's partial-publish window. Because the subpackages carry no `depend: asterisk=X`, the exact pin is the consumer's only version-match guarantor and cannot be loosened. One bad arch took down the **entire** multi-arch manifest because the merge gate required every leg.

Recurring failures:
- `build-batch-wednesday` [#30437475650](https://github.com/andrius/asterisk/actions/runs/30437475650) - armv6/v7, 22.10.1
- `build-batch-tuesday` [#30344620378](https://github.com/andrius/asterisk/actions/runs/30344620378) - arm64, 16.30.1

## Fix (consumer-side resilience)

- **`lib/alpine_sync.py`** - pure `MATRIX_TO_CLOUD`, `install_names()`, `missing_pinned_packages()`.
- **`scripts/check-alpine-apk-availability.py`** (new) - per-arch pre-build gate: `rc 0` build, `rc 2` skip arch, `rc 1` hard fail.
- **`.github/workflows/build-single-image.yml`** - gate before buildx; build/digest steps conditional; a skip-marker artifact per skipped leg; `merge` recomputes `expected = platforms - skipped`. Single-arch members fail loudly (a skip there ships no image).
- **`tests/test_alpine_sync.py`** - +9 tests.

A skipped arch self-heals on the next `alpine-sync` run once the sibling settles.

## Root cause

Fixed upstream in [andrius/asterisk-alpine#40](https://github.com/andrius/asterisk-alpine/pull/40) (merged): publish subpackages first, main last as the sync-wait gate, so "main live / subs missing" can't occur. Tracked in [andrius/asterisk-alpine#39](https://github.com/andrius/asterisk-alpine/issues/39). This PR is the defense-in-depth layer on the consumer side.

## Verification

- `pytest tests/` = 123 passed (incl. 9 new)
- gate run **live** against Cloudsmith: `rc=0` for real armv7 (tds published), `rc=2` for a synthetic bogus pin
- workflow YAML parses; `actionlint` reports no new issues (only pre-existing info-level `${{ }}` SC2086)
- **UNTESTED**: real GHA multi-arch buildx run - the first scheduled batch after merge is the proof
