### PR TITLE
fix(alpine): drop the asterisk-tds (FreeTDS/MSSQL) subpackage

### DIFF
--- a/asterisk/1.8.32.3-alpine-3.24/Dockerfile
+++ b/asterisk/1.8.32.3-alpine-3.24/Dockerfile
@@ -26,7 +26,6 @@ RUN echo "@andrius-asterisk https://dl.cloudsmith.io/public/asterisk/alpine/alpi
         "asterisk-sample-config@andrius-asterisk=1.8.32.3-r0" \
         "asterisk-fax@andrius-asterisk=1.8.32.3-r0" \
         "asterisk-odbc@andrius-asterisk=1.8.32.3-r0" \
-        "asterisk-tds@andrius-asterisk=1.8.32.3-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/14.7.8-alpine-3.24/Dockerfile
+++ b/asterisk/14.7.8-alpine-3.24/Dockerfile
@@ -31,7 +31,6 @@ RUN echo "@andrius-asterisk https://dl.cloudsmith.io/public/asterisk/alpine/alpi
         "asterisk-fax@andrius-asterisk=14.7.8-r0" \
         "asterisk-odbc@andrius-asterisk=14.7.8-r0" \
         "asterisk-mobile@andrius-asterisk=14.7.8-r0" \
-        "asterisk-tds@andrius-asterisk=14.7.8-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/16.30.1-alpine-3.24/Dockerfile
+++ b/asterisk/16.30.1-alpine-3.24/Dockerfile
@@ -31,7 +31,6 @@ RUN echo "@andrius-asterisk https://dl.cloudsmith.io/public/asterisk/alpine/alpi
         "asterisk-fax@andrius-asterisk=16.30.1-r0" \
         "asterisk-odbc@andrius-asterisk=16.30.1-r0" \
         "asterisk-mobile@andrius-asterisk=16.30.1-r0" \
-        "asterisk-tds@andrius-asterisk=16.30.1-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/18.26.4-alpine-3.24/Dockerfile
+++ b/asterisk/18.26.4-alpine-3.24/Dockerfile
@@ -31,7 +31,6 @@ RUN echo "@andrius-asterisk https://dl.cloudsmith.io/public/asterisk/alpine/alpi
         "asterisk-fax@andrius-asterisk=18.26.4-r0" \
         "asterisk-odbc@andrius-asterisk=18.26.4-r0" \
         "asterisk-mobile@andrius-asterisk=18.26.4-r0" \
-        "asterisk-tds@andrius-asterisk=18.26.4-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/20.20.1-alpine-3.24/Dockerfile
+++ b/asterisk/20.20.1-alpine-3.24/Dockerfile
@@ -34,7 +34,6 @@ RUN echo "@andrius-asterisk https://dl.cloudsmith.io/public/asterisk/alpine/alpi
         "asterisk-pgsql@andrius-asterisk=20.20.1-r0" \
         "asterisk-prometheus@andrius-asterisk=20.20.1-r0" \
         "asterisk-mobile@andrius-asterisk=20.20.1-r0" \
-        "asterisk-tds@andrius-asterisk=20.20.1-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/22.10.1-alpine-3.24/Dockerfile
+++ b/asterisk/22.10.1-alpine-3.24/Dockerfile
@@ -34,7 +34,6 @@ RUN echo "@andrius-asterisk https://dl.cloudsmith.io/public/asterisk/alpine/alpi
         "asterisk-pgsql@andrius-asterisk=22.10.1-r0" \
         "asterisk-prometheus@andrius-asterisk=22.10.1-r0" \
         "asterisk-mobile@andrius-asterisk=22.10.1-r0" \
-        "asterisk-tds@andrius-asterisk=22.10.1-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/22.10.1-alpine-edge/Dockerfile
+++ b/asterisk/22.10.1-alpine-edge/Dockerfile
@@ -34,7 +34,6 @@ RUN echo "@andrius-asterisk-edge https://dl.cloudsmith.io/public/asterisk/alpine
         "asterisk-pgsql@andrius-asterisk-edge=22.10.1-r0" \
         "asterisk-prometheus@andrius-asterisk-edge=22.10.1-r0" \
         "asterisk-mobile@andrius-asterisk-edge=22.10.1-r0" \
-        "asterisk-tds@andrius-asterisk-edge=22.10.1-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/23.4.1-alpine-3.24/Dockerfile
+++ b/asterisk/23.4.1-alpine-3.24/Dockerfile
@@ -34,7 +34,6 @@ RUN echo "@andrius-asterisk https://dl.cloudsmith.io/public/asterisk/alpine/alpi
         "asterisk-pgsql@andrius-asterisk=23.4.1-r0" \
         "asterisk-prometheus@andrius-asterisk=23.4.1-r0" \
         "asterisk-mobile@andrius-asterisk=23.4.1-r0" \
-        "asterisk-tds@andrius-asterisk=23.4.1-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/23.4.1-alpine-edge/Dockerfile
+++ b/asterisk/23.4.1-alpine-edge/Dockerfile
@@ -34,7 +34,6 @@ RUN echo "@andrius-asterisk-edge https://dl.cloudsmith.io/public/asterisk/alpine
         "asterisk-pgsql@andrius-asterisk-edge=23.4.1-r0" \
         "asterisk-prometheus@andrius-asterisk-edge=23.4.1-r0" \
         "asterisk-mobile@andrius-asterisk-edge=23.4.1-r0" \
-        "asterisk-tds@andrius-asterisk-edge=23.4.1-r0" \
         bash \
         shadow \
         gettext \

--- a/asterisk/supported-asterisk-builds.yml
+++ b/asterisk/supported-asterisk-builds.yml
@@ -24,7 +24,7 @@ latest_builds:
         alpine_tree: "edge"
         alpine_role: "edge"
         apk_version: "24.0.0_git20260720-r0"
-        apk_packages: ["srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile", "tds"]
+        apk_packages: ["srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile"]
         architectures:
           - "amd64"
           - "arm64"
@@ -83,7 +83,7 @@ latest_builds:
         alpine_tree: "v3.24"
         alpine_role: "stable"
         apk_version: "1.8.32.3-r0"
-        apk_packages: ["fax", "odbc", "tds"]
+        apk_packages: ["fax", "odbc"]
         architectures:
           - "amd64"
     tarball_sha256: "3c12ddbb86e2b901af449bd5a3ac7bbc55a28664159d0c4fb70f89d761d8bf9e"
@@ -156,7 +156,7 @@ latest_builds:
         alpine_tree: "v3.24"
         alpine_role: "stable"
         apk_version: "14.7.8-r0"
-        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "mobile", "tds"]
+        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "mobile"]
         architectures:
           - "amd64"
     tarball_sha256: "3de8b119c3acacc4b54a1fe6cd7b49929394187f19288c684f9ca510826839a1"
@@ -182,7 +182,7 @@ latest_builds:
         alpine_tree: "v3.24"
         alpine_role: "stable"
         apk_version: "16.30.1-r0"
-        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "mobile", "tds"]
+        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "mobile"]
         architectures:
           - "amd64"
           - "arm64"
@@ -230,7 +230,7 @@ latest_builds:
         alpine_tree: "v3.24"
         alpine_role: "stable"
         apk_version: "18.26.4-r0"
-        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "mobile", "tds"]
+        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "mobile"]
         architectures:
           - "amd64"
           - "arm64"
@@ -487,7 +487,7 @@ latest_builds:
         alpine_tree: "v3.24"
         alpine_role: "stable"
         apk_version: "20.20.1-r0"
-        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile", "tds"]
+        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile"]
         architectures:
           - "amd64"
           - "arm64"
@@ -526,7 +526,7 @@ latest_builds:
         alpine_tree: "v3.24"
         alpine_role: "stable"
         apk_version: "22.10.1-r0"
-        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile", "tds"]
+        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile"]
         architectures:
           - "amd64"
           - "arm64"
@@ -537,7 +537,7 @@ latest_builds:
         alpine_tree: "edge"
         alpine_role: "edge"
         apk_version: "22.10.1-r0"
-        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile", "tds"]
+        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile"]
         architectures:
           - "amd64"
           - "arm64"
@@ -584,7 +584,7 @@ latest_builds:
         alpine_tree: "v3.24"
         alpine_role: "stable"
         apk_version: "23.4.1-r0"
-        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile", "tds"]
+        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile"]
         architectures:
           - "amd64"
           - "arm64"
@@ -595,7 +595,7 @@ latest_builds:
         alpine_tree: "edge"
         alpine_role: "edge"
         apk_version: "23.4.1-r0"
-        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile", "tds"]
+        apk_packages: ["opus", "srtp", "curl", "speex", "fax", "odbc", "ldap", "pgsql", "prometheus", "mobile"]
         architectures:
           - "amd64"
           - "arm64"

--- a/configs/generated/asterisk-1.8.32.3-alpine-3.24.yml
+++ b/configs/generated/asterisk-1.8.32.3-alpine-3.24.yml
@@ -43,5 +43,4 @@ alpine:
   apk_packages:
   - fax
   - odbc
-  - tds
   apk_version: 1.8.32.3-r0

--- a/configs/generated/asterisk-14.7.8-alpine-3.24.yml
+++ b/configs/generated/asterisk-14.7.8-alpine-3.24.yml
@@ -48,5 +48,4 @@ alpine:
   - fax
   - odbc
   - mobile
-  - tds
   apk_version: 14.7.8-r0

--- a/configs/generated/asterisk-16.30.1-alpine-3.24.yml
+++ b/configs/generated/asterisk-16.30.1-alpine-3.24.yml
@@ -48,5 +48,4 @@ alpine:
   - fax
   - odbc
   - mobile
-  - tds
   apk_version: 16.30.1-r0

--- a/configs/generated/asterisk-18.26.4-alpine-3.24.yml
+++ b/configs/generated/asterisk-18.26.4-alpine-3.24.yml
@@ -48,5 +48,4 @@ alpine:
   - fax
   - odbc
   - mobile
-  - tds
   apk_version: 18.26.4-r0

--- a/configs/generated/asterisk-20.20.1-alpine-3.24.yml
+++ b/configs/generated/asterisk-20.20.1-alpine-3.24.yml
@@ -51,5 +51,4 @@ alpine:
   - pgsql
   - prometheus
   - mobile
-  - tds
   apk_version: 20.20.1-r0

--- a/configs/generated/asterisk-22.10.1-alpine-3.24.yml
+++ b/configs/generated/asterisk-22.10.1-alpine-3.24.yml
@@ -51,5 +51,4 @@ alpine:
   - pgsql
   - prometheus
   - mobile
-  - tds
   apk_version: 22.10.1-r0

--- a/configs/generated/asterisk-22.10.1-alpine-edge.yml
+++ b/configs/generated/asterisk-22.10.1-alpine-edge.yml
@@ -51,5 +51,4 @@ alpine:
   - pgsql
   - prometheus
   - mobile
-  - tds
   apk_version: 22.10.1-r0

--- a/configs/generated/asterisk-23.4.1-alpine-3.24.yml
+++ b/configs/generated/asterisk-23.4.1-alpine-3.24.yml
@@ -51,5 +51,4 @@ alpine:
   - pgsql
   - prometheus
   - mobile
-  - tds
   apk_version: 23.4.1-r0

--- a/configs/generated/asterisk-23.4.1-alpine-edge.yml
+++ b/configs/generated/asterisk-23.4.1-alpine-edge.yml
@@ -51,5 +51,4 @@ alpine:
   - pgsql
   - prometheus
   - mobile
-  - tds
   apk_version: 23.4.1-r0

--- a/lib/alpine_sync.py
+++ b/lib/alpine_sync.py
@@ -36,9 +36,15 @@ except ImportError:  # imported flat (scripts insert lib/ on sys.path)
 # intersection with what each line actually ships (cert omits ldap/pgsql/...,
 # the git snapshot omits opus). sample-config is installed unconditionally by
 # the Dockerfile, so it is not listed here.
+#
+# tds (cdr_tds/cel_tds -> MSSQL via FreeTDS) is intentionally NOT requested:
+# niche, and apk-tools cannot reliably select asterisk-tds at a pinned version
+# (the "asterisk-tds-22.9.0-r0: breaks world[...]" selection bug). Postgres
+# (pgsql) and ODBC (odbc) CDR backends remain. The sibling repo stops building
+# asterisk-tds in kind.
 DESIRED_SUBPACKAGES = [
     "opus", "srtp", "curl", "speex", "fax",
-    "odbc", "ldap", "pgsql", "prometheus", "mobile", "tds",
+    "odbc", "ldap", "pgsql", "prometheus", "mobile",
 ]
 
 # Cloudsmith arch segment -> our matrix arch name -> docker platform.

--- a/tests/test_alpine_sync.py
+++ b/tests/test_alpine_sync.py
@@ -181,10 +181,12 @@ class TestResolveMembersLive:
 
     def test_subpackages_are_desired_intersect_available_ordered(self):
         m = self._member("22.10.1", "3.24")
-        # desired order preserved, only desired names, all available for 22.10.1
+        # desired order preserved, only desired names, all available for 22.10.1.
+        # tds is intentionally not desired (cdr_tds/cel_tds -> MSSQL via FreeTDS;
+        # apk-tools cannot reliably select asterisk-tds at a pinned version).
         assert m["apk_packages"] == [
             "opus", "srtp", "curl", "speex", "fax", "odbc",
-            "ldap", "pgsql", "prometheus", "mobile", "tds"]
+            "ldap", "pgsql", "prometheus", "mobile"]
 
     def test_git_only_on_edge_with_snapshot_pin(self):
         assert self._member("git", "3.24") is None


### PR DESCRIPTION
## Why

`asterisk-tds` (the `cdr_tds.so` / `cel_tds.so` modules - CDR/CEL logging to **Microsoft SQL Server** via FreeTDS) is the recurring cause of the Alpine build failures:
```
ERROR: unable to select packages:
  asterisk-tds-22.9.0-r0:
    breaks: world[asterisk-tds=22.10.1-r0@andrius-asterisk]
```
`apk-tools` cannot reliably select `asterisk-tds` at a pinned version (documented in the sibling's `packages/1.6/APKBUILD`). It broke armv6/v7/arm64 legs in [build-batch-wednesday #30437475650](https://github.com/andrius/asterisk/actions/runs/30437475650) and [build-batch-tuesday #30344620378](https://github.com/andrius/asterisk/actions/runs/30344620378). The Debian images **never** built the TDS modules, so Alpine was inconsistent anyway.

## Change

- Remove `tds` from `DESIRED_SUBPACKAGES` in `lib/alpine_sync.py`.
- Remove `- tds` from the 10 committed `os_matrix.apk_packages` lists in `asterisk/supported-asterisk-builds.yml`.
- Regenerate the 9 Alpine configs + Dockerfiles (one `asterisk-tds@...=ver` line fewer per Dockerfile).
- Update the resolver test.

**Postgres (`pgsql`) and ODBC (`odbc`) CDR backends are untouched.** The sibling still publishes `asterisk-tds` as an apk for now, so any MSSQL user can `apk add asterisk-tds` at runtime - we just stop baking a niche, chronically-failing module into the image.

## Companion

Sibling [andrius/asterisk-alpine#41](https://github.com/andrius/asterisk-alpine/pull/41) stops **building** `asterisk-tds` (drops `--with-tds`, `freetds-dev`, the subpackage, across all APKBUILDs; pgsql/odbc kept, verified with real `abuild -r`).

## Verification

- `pytest tests/` = 123 passed
- diff scoped to: `lib/alpine_sync.py`, `supported-asterisk-builds.yml`, 9 Alpine configs, 9 Alpine Dockerfiles, 1 test - no Debian drift
- `grep tds` over `configs/generated/asterisk-*-alpine-*.yml` -> clean
